### PR TITLE
Change '*' to 'update' as default task operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Opionally, a task may define the following properties
 
 - A _description_, this is a string or a function that describes the task purpose. It is used for logging by the Agent.
 - A _path_. This is a pointer to a part of the state that this action applies to, it defaults to '/', meaning task by default apply to the full state object. This will become more clear in the next example.
-- An operation _op_ (`create`, `update`, `delete`), that this task is applicable for, for instance certain tasks may be relevant only when _deleting_ a certain element of the state (e.g. removing a system service). This property defaults to `*`, meaning the task is by default applicable to any operation.
+- An operation _op_ (`create`, `update`, `delete`), that this task is applicable for, for instance certain tasks may be relevant only when _deleting_ a certain element of the state (e.g. removing a system service). This property defaults to `update`, meaning the task is by default applicable to any operation (as `'update' = 'delete' + 'create'`).
 
 Continuing with our example, as we defined a task to turn the heater ON, we need to define another to turn the heater resistor OFF.
 

--- a/tests/.mocharc.js
+++ b/tests/.mocharc.js
@@ -3,5 +3,5 @@ module.exports = {
 	exit: true, // Force Mocha to exit after tests complete
 	recursive: true, // Look for tests in subdirectories
 	require: ['ts-node/register/transpile-only', 'tsconfig-paths/register'],
-	timeout: '20000', // Give a larger timeout as some of the integration tests may take a while
+	timeout: '30000', // Give a larger timeout as some of the integration tests may take a while
 };

--- a/tests/container-compose.spec.ts
+++ b/tests/container-compose.spec.ts
@@ -446,7 +446,7 @@ describe('container-compose', () => {
 					.map(({ Id }) => docker.getContainer(Id).remove({ force: true })),
 			);
 
-			await docker.pruneImages();
+			await docker.pruneImages({ filters: { dangling: { false: true } } });
 		};
 
 		beforeEach(async () => {
@@ -498,7 +498,6 @@ describe('container-compose', () => {
 				.to.have.property('Running')
 				.that.equals(false);
 
-			console.log(agent.state());
 			await agent.target({
 				services: {
 					main: {


### PR DESCRIPTION
After creating the applicability table between tasks and state operations, it became clear that these two values had the same effect, so '*' was removed for simplicity

Change-type: minor