### PR TITLE
Allow providing a planner instance to Agent init

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,18 +3,11 @@ version: '2.4'
 services:
   sut:
     build: ./
-    command:
-      [
-        './tests/wait-for-it.sh',
-        '--',
-        'npm',
-        'run',
-        'test:integration'
-      ]
+    command: ['./tests/wait-for-it.sh', '--', 'npm', 'run', 'test:integration']
     stop_grace_period: 3s
     environment:
       DOCKER_HOST: 'unix:///var/run/docker.sock'
-      DEBUG: 'mahler:warn,mahler:error'
+      DEBUG: 'mahler:warn,mahler:error,mahler:info'
     volumes:
       - dind:/var/run
     depends_on:

--- a/tests/container-compose.spec.ts
+++ b/tests/container-compose.spec.ts
@@ -80,7 +80,7 @@ const fetch = Task.of({
 		};
 	},
 	description: (service) =>
-		`pulling image '${service.target.image}' for service '${service.name}'`,
+		`pull image '${service.target.image}' for service '${service.name}'`,
 });
 
 const install = Task.of({
@@ -263,7 +263,7 @@ describe('container-compose', () => {
 
 			if (result.success) {
 				expect(result.plan.map((a) => a.description)).to.deep.equal([
-					"pulling image 'alpine:latest' for service 'main'",
+					"pull image 'alpine:latest' for service 'main'",
 					"installing container for service 'main'",
 					"starting container for service 'main'",
 				]);
@@ -350,7 +350,7 @@ describe('container-compose', () => {
 
 			if (result.success) {
 				expect(result.plan.map((a) => a.description)).to.deep.equal([
-					"pulling image 'alpine:latest' for service 'main'",
+					"pull image 'alpine:latest' for service 'main'",
 					"installing container for service 'main'",
 					"starting container for service 'main'",
 					"stopping container for service 'main'",
@@ -385,7 +385,7 @@ describe('container-compose', () => {
 
 			if (result.success) {
 				expect(result.plan.map((a) => a.description)).to.deep.equal([
-					"pulling image 'alpine:3.14' for service 'main'",
+					"pull image 'alpine:3.14' for service 'main'",
 					"stopping container for service 'main'",
 					"removing container for service 'main'",
 					"installing container for service 'main'",
@@ -421,7 +421,7 @@ describe('container-compose', () => {
 
 			if (result.success) {
 				expect(result.plan.map((a) => a.description)).to.deep.equal([
-					"pulling image 'alpine:3.14' for service 'main'",
+					"pull image 'alpine:3.14' for service 'main'",
 					"removing container for service 'main'",
 					"installing container for service 'main'",
 					"starting container for service 'main'",
@@ -494,7 +494,7 @@ describe('container-compose', () => {
 		it('can execute a single container plan', async () => {
 			const agent = Agent.of<App>({
 				initial: { name: appname, services: {}, images: [] },
-				tasks: [fetch, install, start, stop, remove],
+				planner,
 				opts: { pollIntervalMs: 1000, logger: console },
 			});
 


### PR DESCRIPTION
This allows custom planners to be given to an agent instance.

Change-type: minor