### PR TITLE
Remove tests from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,16 @@
     "url": "https://github.com/balena-io-modules/mahler/issues"
   },
   "files": [
-    "build/"
+    "build/",
+    "CHANGELOG.md",
+    "README.md"
   ],
   "engines": {
     "node": ">=16.0.0"
   },
   "scripts": {
     "clean": "rimraf build",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc --project tsconfig.release.json",
     "lint": "balena-lint --typescript lib tests",
     "lint-fix": "balena-lint --typescript --fix lib tests",
     "test:node": "mocha --reporter spec lib/**/*.spec.ts --config tests/.mocharc.js",

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -1,0 +1,5 @@
+{
+	"extends": "./tsconfig.json",
+	"include": ["lib/**/*.ts"],
+	"exclude": ["lib/**/*.spec.ts"]
+}


### PR DESCRIPTION
Fix package build by removing tests. Before the package would be unusable as the configuration in `package.json` would not match the build folder structure.

Change-type: patch