### PR TITLE
 Add support for redirect tasks

### DIFF
--- a/lib/planner/findPlan.ts
+++ b/lib/planner/findPlan.ts
@@ -3,7 +3,7 @@ import { Path } from '../path';
 import { Operation } from '../operation';
 import { Pointer } from '../pointer';
 import { Context } from '../context';
-import { Action, Method, Instruction, Task } from '../task';
+import { Action, Method, Instruction, Task, Redirect } from '../task';
 import { PlannerConfig, PlanningResult, PlanningStats } from './types';
 import { isTaskApplicable } from './utils';
 
@@ -16,7 +16,7 @@ interface PlanningState<TState = any> {
 	trace?: PlannerConfig['trace'];
 	initialPlan?: Array<Action<TState>>;
 	stats?: PlanningStats;
-	callStack?: Array<Method<TState>>;
+	callStack?: Array<Method<TState> | Redirect<TState>>;
 }
 
 function tryAction<TState = any>(
@@ -100,6 +100,60 @@ function tryMethod<TState = any>(
 	return { success: true, state, plan, stats };
 }
 
+function tryRedirect<TState = any>(
+	redirect: Redirect<TState>,
+	{
+		current: state,
+		trace = () => {
+			/* noop */
+		},
+		depth = 0,
+		stats = { iterations: 0, maxDepth: 0, time: 0 },
+		callStack = [],
+		initialPlan = [],
+		...pState
+	}: PlanningState<TState>,
+): PlanningResult<TState> {
+	if (callStack.find((r) => Redirect.equals(r, redirect))) {
+		trace({
+			depth,
+			redirect: redirect.description,
+			operation: pState.operation,
+			error:
+				'recursion detected, redirection already in stack for the same target',
+		});
+		// We do not trace an error here as this should be fairly common
+		return { success: false, stats };
+	}
+
+	const output = redirect(state);
+	const targets = Array.isArray(output) ? output : [output];
+
+	const plan: Array<Action<TState>> = [];
+	for (const target of targets) {
+		const res = findPlan({
+			...pState,
+			current: state,
+			depth: depth + 1,
+			diff: Diff.of(state, target),
+			initialPlan: [...initialPlan, ...plan],
+			trace,
+			stats,
+			callStack: [...callStack, redirect],
+		});
+
+		if (!res.success) {
+			return res;
+		}
+
+		plan.push(...res.plan);
+		state = res.state;
+		stats = res.stats;
+	}
+
+	return { success: true, state, plan, stats };
+}
+
 function tryInstruction<TState = any>(
 	instruction: Instruction<TState>,
 	{
@@ -132,6 +186,12 @@ function tryInstruction<TState = any>(
 	let res: PlanningResult<TState>;
 	if (Method.is(instruction)) {
 		res = tryMethod(instruction, { ...state, trace, stats });
+	} else if (Redirect.is(instruction)) {
+		res = tryRedirect(instruction, {
+			...state,
+			trace,
+			stats,
+		});
 	} else {
 		res = tryAction(instruction, { ...state, trace, stats });
 	}

--- a/lib/planner/index.ts
+++ b/lib/planner/index.ts
@@ -33,12 +33,12 @@ function of<TState = any>({
 		taskIds.add(t.id);
 	});
 
-	// Sort the tasks putting methods first
+	// Sort the tasks putting methods and redirects first
 	tasks = tasks.sort((a, b) => {
-		if (Task.isMethod(a) && Task.isAction(b)) {
+		if ((Task.isMethod(a) || Task.isRedirect(a)) && Task.isAction(b)) {
 			return -1;
 		}
-		if (Task.isAction(a) && Task.isMethod(b)) {
+		if (Task.isAction(a) && (Task.isMethod(b) || Task.isRedirect(b))) {
 			return 1;
 		}
 		return 0;

--- a/tests/orchestrator/planner.ts
+++ b/tests/orchestrator/planner.ts
@@ -13,6 +13,7 @@ import {
 	removeService,
 	removeRelease,
 	removeApp,
+	updateApp,
 } from './tasks';
 
 export const planner = Planner.of<Device>({
@@ -31,6 +32,23 @@ export const planner = Planner.of<Device>({
 		removeService,
 		removeRelease,
 		removeApp,
+	],
+	config: { trace: console.trace },
+});
+
+export const plannerWithRedirect = Planner.of<Device>({
+	tasks: [
+		fetch,
+		createApp,
+		createRelease,
+		migrateService,
+		installService,
+		startService,
+		stopService,
+		removeService,
+		removeRelease,
+		removeApp,
+		updateApp,
 	],
 	config: { trace: console.trace },
 });

--- a/tests/orchestrator/planning.spec.ts
+++ b/tests/orchestrator/planning.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '~/tests';
 
 import { ServiceStatus } from './state';
-import { planner } from './planner';
+import { planner, plannerWithRedirect } from './planner';
 import { DELETED } from 'lib/target';
 
 describe('orchestrator/planning', () => {
@@ -383,6 +383,75 @@ describe('orchestrator/planning', () => {
 				"remove release 'r0'",
 				"pull image 'alpine:latest' for service 'other' of app 'a0'",
 				"create container for service 'other' of app 'a0' and release 'r1'",
+				"start container for service 'other' of app 'a0' and release 'r1'",
+			]);
+		} else {
+			expect.fail('Plan not found');
+		}
+	});
+
+	it('when using redirect, it installs and migrates before removing the current release', () => {
+		const device = {
+			name: 'test',
+			uuid: 'd0',
+			apps: {
+				a0: {
+					name: 'test-app',
+					releases: {
+						r0: {
+							services: {
+								main: {
+									image: 'alpine:latest',
+									command: ['sleep', 'infinity'],
+									status: 'running' as ServiceStatus,
+									containerId: 'c0',
+								},
+							},
+						},
+					},
+				},
+			},
+			keys: {},
+			images: [{ name: 'a0_main:r0' }],
+		};
+
+		const result = plannerWithRedirect.findPlan(device, {
+			apps: {
+				a0: {
+					name: 'test-app',
+					releases: {
+						r0: DELETED,
+						r1: {
+							services: {
+								// main service has not changed
+								main: {
+									image: 'alpine:latest',
+									command: ['sleep', 'infinity'],
+									status: 'running',
+								},
+								other: {
+									image: 'alpine:latest',
+									command: ['sleep', '30'],
+									status: 'running',
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+
+		if (result.success) {
+			expect(result.plan.map((a) => a.description)).to.deep.equal([
+				"prepare release 'r1'",
+				// First create the new services and migrate those already running
+				"pull image 'alpine:latest' for service 'main' of app 'a0'",
+				"migrate unchanged service 'main' of app 'a0 to release 'r1' '",
+				"pull image 'alpine:latest' for service 'other' of app 'a0'",
+				"create container for service 'other' of app 'a0' and release 'r1'",
+				// Then remove the release
+				"remove release 'r0'",
+				// Finally start the target containers
 				"start container for service 'other' of app 'a0' and release 'r1'",
 			]);
 		} else {

--- a/tests/orchestrator/tasks.ts
+++ b/tests/orchestrator/tasks.ts
@@ -2,7 +2,7 @@ import * as Docker from 'dockerode';
 import * as tar from 'tar-stream';
 
 import { console } from '~/tests';
-import { Task, Constructor, Pure } from '~/lib';
+import { Task, Constructor, Pure, DELETED, Target } from '~/lib';
 import { Device, Service, ServiceStatus } from './state';
 import { getImageName, getRegistryAndName, getContainerName } from './utils';
 
@@ -514,4 +514,150 @@ export const removeApp = Pure.of({
 		Object.keys(ctx.get(device).releases).length === 0,
 	effect: (device: Device, ctx) => ctx.del(device),
 	description: (ctx) => `remove app '${ctx.appUuid}'`,
+});
+
+/*
+ * Update an app
+ *
+ * This uses a `redirect` task. We can perform different strategies to
+ * update an app depending on the requirements, in this case, if we are udpating
+ * an app to a new release we can think of it as three separate steps
+ *
+ * - First pull images and create any changing services in the target release, any migrating services can be safely
+ *   migrated now
+ * - Uninstall the running release
+ * - Start the services from the target release
+ *
+ * The redirect task returns intermediate targets for the planner to follow as a way
+ * to guide the planning without imposing too many restrictions.
+ *
+ * Condition: there are releases in the current state that are not
+ * in the target state of the same app
+ * Redirect: [ update and migrate services, uninstall the running release]
+ */
+export const updateApp = Task.of({
+	op: 'update',
+	path: '/apps/:appUuid',
+	// This only applies to an app that is updating between releases
+	condition: (device: Device, ctx) => {
+		const currentReleases = Object.keys(ctx.get(device).releases);
+		const targetReleases = Object.keys(ctx.target.releases);
+
+		// There is a release in current that is not part of the target
+		// state
+		return (
+			targetReleases.length > 0 &&
+			currentReleases.some((cR) => !targetReleases.find((tR) => cR === tR))
+		);
+	},
+	// NOTE: we need to set the method return otherwise the
+	// compiler cannot infer the right generics for the task
+	redirect: (device: Device, ctx): Array<Target<Device>> => {
+		const currentReleases = Object.keys(ctx.get(device).releases);
+		const targetReleases = Object.keys(ctx.target.releases);
+
+		const currentRelease = currentReleases.find(
+			(cR) => !targetReleases.find((tR) => cR === tR),
+		)!;
+		const [targetRelease] = targetReleases;
+		const currentServices =
+			ctx.get(device).releases[currentRelease]?.services || {};
+		const targetServices = ctx.target.releases[targetRelease]?.services || {};
+
+		// find services that need to be updated/installed vs migrated
+		const unchangedServices: string[] = [];
+		const updatedOrNewServices: string[] = [];
+		for (const serviceName of Object.keys(targetServices)) {
+			// If the service is in both the current state and target state
+			// with the same configuration and image
+			if (
+				currentServices[serviceName] != null &&
+				isEqualConfig(
+					currentServices[serviceName],
+					targetServices[serviceName],
+				) &&
+				targetServices[serviceName].image === currentServices[serviceName].image
+			) {
+				unchangedServices.push(serviceName);
+			} else {
+				updatedOrNewServices.push(serviceName);
+			}
+		}
+
+		// The first target keeps both the current and target releases
+		const installAndMigrateServices = {
+			[currentRelease]: {
+				services: Object.keys(currentServices).reduce(
+					(services, serviceName) => {
+						// Delete from the current state any services that need to be migrated
+						if (unchangedServices.includes(serviceName)) {
+							return {
+								...services,
+								[serviceName]: DELETED,
+							};
+						}
+
+						// Keep the state unchanged for the rest
+						return {
+							...services,
+							[serviceName]: currentServices[serviceName],
+						};
+					},
+					{},
+				),
+			},
+			[targetRelease]: {
+				services: Object.keys(targetServices).reduce(
+					(services, serviceName) => {
+						if (unchangedServices.includes(serviceName)) {
+							return {
+								...services,
+								// Keep the status of the service as this does not need to be changed
+								[serviceName]: targetServices[serviceName],
+							};
+						}
+
+						if (updatedOrNewServices.includes(serviceName)) {
+							return {
+								...services,
+								// Only install the services, do not start them yet
+								[serviceName]: {
+									...targetServices[serviceName],
+									status: 'created',
+								},
+							};
+						}
+
+						return services;
+					},
+					{},
+				),
+			},
+		};
+
+		// This returns two targets
+		return [
+			// First install the new release and migrate the services
+			{
+				apps: {
+					[ctx.appUuid]: {
+						releases: installAndMigrateServices,
+					},
+				},
+			},
+			// Then delete the current release keeping the target release
+			// state untouched
+			{
+				apps: {
+					[ctx.appUuid]: {
+						releases: {
+							[currentRelease]: DELETED,
+							[targetRelease]: installAndMigrateServices[targetRelease],
+						},
+					},
+				},
+			},
+		];
+	},
+	description: (ctx) => `update app '${ctx.appUuid}'`,
 });


### PR DESCRIPTION
A redirect task allows to define one or more targets for the planner to seek when
receiving a target. For instance, if the agent is a robot that
needs to get from A -> B but there is an obstacle in the path, then the
task could identify the obstacle and tell the planner to go from A -> C
and then from C -> B in order to reach the target.

Change-type: minor
 
