### PR TITLE
Refactor planner module

### DIFF
--- a/lib/agent/index.ts
+++ b/lib/agent/index.ts
@@ -57,7 +57,7 @@ function of<TState>({
 	opts: userOpts = {},
 	planner = Planner.of({
 		tasks,
-		opts: { trace: userOpts.logger?.trace ?? NullLogger.trace },
+		config: { trace: userOpts.logger?.trace ?? NullLogger.trace },
 	}),
 }: {
 	initial: TState;

--- a/lib/agent/runtime.ts
+++ b/lib/agent/runtime.ts
@@ -87,7 +87,7 @@ export class Runtime<TState> {
 						tries,
 						status: 'finding plan to target',
 					});
-					const result = this.planner.find(this.internal, this.target);
+					const result = this.planner.findPlan(this.internal, this.target);
 					logger.debug('planning stats', JSON.stringify(result.stats));
 
 					if (!result.success) {

--- a/lib/diff.ts
+++ b/lib/diff.ts
@@ -4,7 +4,7 @@ import { Path } from './path';
 import { Target, DELETED } from './target';
 
 /**
- * A diff is a function that allows to a list of pending operations and a
+ * A diff is a function that allows to find a list of pending operations to a
  * target.
  */
 export interface Diff<S> {

--- a/lib/planner.spec.ts
+++ b/lib/planner.spec.ts
@@ -27,7 +27,6 @@ describe('Planner', () => {
 			};
 
 			const take = Task.of({
-				op: 'create',
 				path: '/blocks/:block',
 				condition: (s: State, location) =>
 					isClear(s.blocks, location.block) && s.hand == null,
@@ -109,10 +108,10 @@ describe('Planner', () => {
 
 			const planner = Planner.of<State>({
 				tasks: [take, put, move],
-				opts: { trace: console.trace },
+				config: { trace: console.trace },
 			});
 
-			const result = planner.find(
+			const result = planner.findPlan(
 				{
 					blocks: { a: 'table', b: 'a', c: 'b' },
 				},
@@ -308,10 +307,10 @@ describe('Planner', () => {
 
 			const planner = Planner.of<State>({
 				tasks: [pickup, unstack, putdown, stack, take, put, move],
-				opts: { trace: console.trace },
+				config: { trace: console.trace },
 			});
 
-			const result = planner.find(
+			const result = planner.findPlan(
 				{
 					blocks: { a: 'table', b: 'a', c: 'b' },
 				},

--- a/lib/planner.ts
+++ b/lib/planner.ts
@@ -45,23 +45,6 @@ export interface PlannerOpts {
 	trace: (...args: any[]) => void;
 }
 
-function extractPath(t: Path, p: Path) {
-	const tParts = Path.elems(t);
-	const pParts = Path.elems(p);
-
-	return (
-		'/' +
-		tParts
-			.map((e, i) => {
-				if (e.startsWith(':')) {
-					return pParts[i];
-				}
-				return e;
-			})
-			.join('/')
-	);
-}
-
 function expandMethod<TState = any>(
 	state: TState,
 	instruction: Instruction<TState>,
@@ -127,7 +110,7 @@ function findPlan<TState = any>({
 
 			// Extract the path from the task template and the
 			// operation
-			const path = extractPath(task.path, operation.path);
+			const path: Path = operation.path;
 
 			// Get the context expected by the task
 			// we get the target value for the context from the pointer

--- a/lib/planner/findPlan.ts
+++ b/lib/planner/findPlan.ts
@@ -1,0 +1,251 @@
+import { Diff } from '../diff';
+import { Path } from '../path';
+import { Operation } from '../operation';
+import { Pointer } from '../pointer';
+import { Context } from '../context';
+import { Action, Method, Instruction, Task } from '../task';
+import { PlannerConfig, PlanningResult, PlanningStats } from './types';
+import { isTaskApplicable } from './utils';
+
+interface PlanningState<TState = any> {
+	current: TState;
+	diff: Diff<TState>;
+	tasks: Array<Task<TState>>;
+	depth?: number;
+	operation?: Operation<TState, any>;
+	trace?: PlannerConfig['trace'];
+	initialPlan?: Array<Action<TState>>;
+	stats?: PlanningStats;
+	callStack?: Array<Method<TState>>;
+}
+
+function tryAction<TState = any>(
+	action: Action<TState>,
+	{
+		depth,
+		operation,
+		current,
+		initialPlan = [],
+		trace = () => {
+			/* noop */
+		},
+		stats = { iterations: 0, maxDepth: 0, time: 0 },
+	}: PlanningState<TState>,
+): PlanningResult<TState> {
+	// Detect loops in the plan
+	if (initialPlan.find((a) => Action.equals(a, action))) {
+		trace({
+			depth,
+			operation,
+			action: action.description,
+			error: 'loop detected, action already in plan',
+		});
+		return { success: false, stats };
+	}
+	const state = action.effect(current);
+
+	return { success: true, state, plan: [action], stats };
+}
+
+function tryMethod<TState = any>(
+	method: Method<TState>,
+	{
+		current: state,
+		trace = () => {
+			/* noop */
+		},
+		initialPlan = [],
+		stats = { iterations: 0, maxDepth: 0, time: 0 },
+		callStack = [],
+		...pState
+	}: PlanningState<TState>,
+): PlanningResult<TState> {
+	// look method in the call stack
+	if (callStack.find((m) => Method.equals(m, method))) {
+		trace({
+			depth: pState.depth,
+			method: method.description,
+			operation: pState.operation,
+			error:
+				'recursion detected, method call already in stack for the same target',
+		});
+		return { success: false, stats };
+	}
+
+	const instructions = method(state);
+	if (instructions.length === 0) {
+		return { success: false, stats };
+	}
+
+	const plan: Array<Action<TState>> = [];
+	for (const i of instructions) {
+		const res = tryInstruction(i, {
+			...pState,
+			trace,
+			current: state,
+			initialPlan: [...initialPlan, ...plan],
+			callStack: [...callStack, method],
+			stats,
+		});
+
+		if (!res.success) {
+			return res;
+		}
+
+		plan.push(...res.plan);
+		state = res.state;
+		stats = res.stats;
+	}
+
+	return { success: true, state, plan, stats };
+}
+
+function tryInstruction<TState = any>(
+	instruction: Instruction<TState>,
+	{
+		trace = () => {
+			/* noop */
+		},
+		stats = { iterations: 0, maxDepth: 0, time: 0 },
+		...state
+	}: PlanningState<TState>,
+): PlanningResult<TState> {
+	trace({
+		depth: state.depth,
+		operation: state.operation,
+		instruction: instruction.description,
+		status: 'trying instruction',
+	});
+
+	// test condition
+	if (!instruction.condition(state.current)) {
+		trace({
+			depth: state.depth,
+			state: state.current,
+			operation: state.operation,
+			instruction: instruction.description,
+			error: 'condition not met',
+		});
+		return { success: false, stats };
+	}
+
+	let res: PlanningResult<TState>;
+	if (Method.is(instruction)) {
+		res = tryMethod(instruction, { ...state, trace, stats });
+	} else {
+		res = tryAction(instruction, { ...state, trace, stats });
+	}
+
+	if (res.success) {
+		trace({
+			depth: state.depth,
+			operation: state.operation,
+			instruction: instruction.description,
+			status: 'instruction selected',
+		});
+	}
+	return res;
+}
+
+export function findPlan<TState = any>({
+	current,
+	diff,
+	tasks,
+	trace = () => {
+		/* noop */
+	},
+	depth = 0,
+	initialPlan = [],
+	stats = { iterations: 0, maxDepth: 0, time: 0 },
+	callStack = [],
+}: PlanningState<TState>): PlanningResult<TState> {
+	// Get the list of operations from the patch
+	const ops = diff(current);
+
+	// If there are no operations left, we have reached
+	// the target
+	if (ops.length === 0) {
+		const maxDepth = stats.maxDepth < depth ? depth : stats.maxDepth;
+		trace({
+			depth,
+			state: current,
+			plan: initialPlan.map((a) => a.description),
+			stats: { maxDepth, iterations: stats.iterations },
+			status: 'plan found',
+		});
+		return {
+			success: true,
+			plan: [],
+			state: current,
+			stats: { ...stats, maxDepth },
+		};
+	}
+
+	trace({
+		depth,
+		state: current,
+		target: diff.target,
+		pending: ops,
+		plan: initialPlan.map((a) => a.description),
+		status: 'finding plan',
+	});
+
+	for (const operation of ops) {
+		// Find the tasks that are applicable to the operations
+		const applicable = tasks.filter((t) => isTaskApplicable(t, operation));
+		for (const task of applicable) {
+			stats.iterations++;
+
+			// Extract the path from the task template and the
+			// operation
+			const path: Path = operation.path;
+
+			// Get the context expected by the task
+			// we get the target value for the context from the pointer
+			// if the operation is delete, the pointer will be undefined
+			// which is the right value for that operation
+			const ctx = Context.of<TState, any, any>(
+				task.path,
+				path,
+				Pointer.of(diff.target, path)!,
+			);
+
+			const taskRes = tryInstruction(task(ctx as any), {
+				depth,
+				current,
+				diff,
+				tasks,
+				trace,
+				operation,
+				initialPlan,
+				stats,
+				callStack,
+			});
+
+			if (taskRes.success && taskRes.plan.length > 0) {
+				const res = findPlan({
+					depth: depth + 1,
+					current: taskRes.state,
+					diff,
+					tasks,
+					trace,
+					initialPlan: [...initialPlan, ...taskRes.plan],
+					stats: taskRes.stats,
+					callStack,
+				});
+
+				if (res.success) {
+					return { ...res, plan: [...taskRes.plan, ...res.plan] };
+				}
+			}
+		}
+	}
+
+	return {
+		success: false,
+		stats: {
+			...stats,
+			maxDepth: stats.maxDepth < depth ? depth : stats.maxDepth,
+		},
+	};
+}

--- a/lib/planner/index.ts
+++ b/lib/planner/index.ts
@@ -1,10 +1,10 @@
-import { Path } from './path';
-import { Pointer } from './pointer';
-import { Context } from './context';
-import { Task, Action, Instruction, Method } from './task';
-import { Target } from './target';
-import { Diff } from './diff';
-import { assert } from './assert';
+import { Path } from '../path';
+import { Pointer } from '../pointer';
+import { Context } from '../context';
+import { Task, Action, Instruction, Method } from '../task';
+import { Target } from '../target';
+import { Diff } from '../diff';
+import { assert } from '../assert';
 
 interface PlannerStats {
 	/**

--- a/lib/planner/index.ts
+++ b/lib/planner/index.ts
@@ -1,283 +1,27 @@
-import { Path } from '../path';
-import { Pointer } from '../pointer';
-import { Context } from '../context';
-import { Task, Action, Instruction, Method } from '../task';
 import { Target } from '../target';
+import { Task } from '../task';
+import { PlanningResult, PlannerConfig } from './types';
 import { Diff } from '../diff';
 import { assert } from '../assert';
+import { findPlan } from './findPlan';
 
-interface PlannerStats {
-	/**
-	 * Number of iterations (tasks tested) in total
-	 */
-	iterations: number;
-
-	/**
-	 * Search depth
-	 */
-	depth: number;
-
-	/**
-	 * Total search time in ms
-	 */
-	time: number;
-}
-
-export type PlannerResult<TState> =
-	| { success: true; plan: Array<Action<TState>>; stats: PlannerStats }
-	| { success: false; stats: PlannerStats };
+export * from './types';
 
 export interface Planner<TState = any> {
 	/**
 	 * Calculate a plan to get from the current state
 	 * to the target state. It will throw an exception if a plan
 	 * cannot be found.
-	 * TODO: accept a diff too
 	 */
-	find(current: TState, target: Target<TState>): PlannerResult<TState>;
-}
-
-export interface PlannerOpts {
-	/**
-	 * A function used by the planner to debug the search
-	 * for a plan. It defaults to a noop.
-	 */
-	trace: (...args: any[]) => void;
-}
-
-function expandMethod<TState = any>(
-	state: TState,
-	instruction: Instruction<TState>,
-): Array<Action<TState>> {
-	// QUESTION: if some instructions are not applicable,
-	// should we stop the operation entirely to avoid testing
-	// a plan that is not valid?
-	if (Method.is(instruction)) {
-		return instruction(state).flatMap((i) => expandMethod(state, i));
-	}
-
-	return [instruction];
-}
-
-// Parameters for the plan function
-// Level
-// Target as a combination of the level patches
-// Tentative plan
-// Stack ?
-function findPlan<TState = any>({
-	current,
-	diff,
-	tasks,
-	trace = () => {
-		/* noop */
-	},
-	initial = [],
-	stats = { iterations: 0, depth: 0, time: 0 },
-}: {
-	current: TState;
-	diff: Diff<TState>;
-	tasks: Array<Task<TState>>;
-	trace?: PlannerOpts['trace'];
-	initial?: Array<Action<TState>>;
-	stats?: PlannerStats;
-}): PlannerResult<TState> {
-	// Get the list of operations from the patch
-	const ops = diff(current);
-
-	// If there are no operations left, we have reached
-	// the target
-	if (ops.length === 0) {
-		return { success: true, plan: [], stats };
-	}
-
-	trace({
-		depth: stats.depth,
-		current,
-		target: diff.target,
-		pending: ops,
-		plan: initial.map((a) => a.description),
-	});
-	for (const operation of ops) {
-		// Find the tasks that are applicable to the operations
-		const applicable = tasks.filter((t) => Task.isApplicable(t, operation));
-		trace({
-			depth: stats.depth,
-			operation,
-			status: 'looking for applicable tasks',
-		});
-		for (const task of applicable) {
-			stats.iterations++;
-
-			// Extract the path from the task template and the
-			// operation
-			const path: Path = operation.path;
-
-			// Get the context expected by the task
-			// we get the target value for the context from the pointer
-			// if the operation is delete, the pointer will be undefined
-			// which is the right value for that operation
-			const ctx = Context.of<TState, any, any>(
-				task.path,
-				path,
-				Pointer.of(diff.target, path)!,
-			);
-
-			const description =
-				typeof task.description === 'function'
-					? task.description(ctx as any)
-					: task.description;
-
-			// We check early if the action already exists on the path to
-			// improve debugging
-			if (Task.isAction(task)) {
-				const action = task(ctx as any);
-				if (initial.find((a) => Action.equals(a, action))) {
-					continue;
-				}
-			}
-
-			// If the task condition is not met, then go to the next task
-			trace({
-				depth: stats.depth,
-				operation,
-				task: description,
-				status: 'checking condition',
-			});
-			if (!task.condition(current, ctx as any)) {
-				trace({
-					depth: stats.depth,
-					operation,
-					task: description,
-					status: 'condition is not met',
-				});
-				continue;
-			}
-
-			if (Task.isMethod(task)) {
-				// If the task is a method we need to expand it recursively and check that none of
-				// the operations has an invalid condition
-				// if all of the operations are applicable, continue evaluating the plan with the
-				// added operations
-				trace({
-					depth: stats.depth,
-					operation,
-					method: description,
-					status: 'expanding method',
-				});
-				const actions = expandMethod(current, task(ctx as any));
-				if (actions.length === 0) {
-					continue;
-				}
-
-				let state = current;
-				let isValid = true;
-				for (const action of actions) {
-					trace({
-						depth: stats.depth,
-						operation,
-						method: description,
-						action: action.description,
-						status: 'testing condition',
-					});
-					if (!action.condition(state)) {
-						trace({
-							depth: stats.depth,
-							operation,
-							method: description,
-							action: action.description,
-							status: 'condition is not met',
-							state,
-						});
-						isValid = false;
-						break;
-					}
-
-					// Prevent loops by avoiding adding the same instruction over
-					// and over to the plane
-					if (initial.find((a) => Action.equals(a, action))) {
-						// TODO: perhaps add something to the stats about avoided
-						// loops?
-						trace({
-							depth: stats.depth,
-							operation,
-							method: description,
-							action: action.description,
-							status: 'action already in plan',
-						});
-						isValid = false;
-						break;
-					}
-					state = action.effect(state);
-				}
-
-				// This is not a valid path
-				if (!isValid) {
-					continue;
-				}
-				trace({
-					depth: stats.depth,
-					operation,
-					method: description,
-					status: 'selected',
-				});
-
-				// This is a valid path, continue finding a plan recursively
-				const res = findPlan({
-					current: state,
-					diff,
-					tasks,
-					trace,
-					initial: [...initial, ...actions],
-					stats: { ...stats, depth: stats.depth + 1 },
-				});
-
-				if (res.success) {
-					return { ...res, plan: [...actions, ...res.plan] };
-				}
-			} else {
-				// If the task is an action, then we can just apply it
-				const action = task(ctx as any);
-				const state = action.effect(current);
-
-				trace({
-					depth: stats.depth,
-					operation,
-					action: description,
-					status: 'selected',
-				});
-				const res = findPlan({
-					current: state,
-					diff,
-					tasks,
-					trace,
-					initial: [...initial, action],
-					stats: { ...stats, depth: stats.depth + 1 },
-				});
-
-				if (res.success) {
-					return { ...res, plan: [action, ...res.plan] };
-				}
-			}
-		}
-
-		if (applicable.length === 0) {
-			trace({
-				depth: stats.depth,
-				operation,
-				status: 'no applicable task found',
-			});
-		}
-	}
-
-	return { success: false, stats };
+	findPlan(current: TState, target: Target<TState>): PlanningResult<TState>;
 }
 
 function of<TState = any>({
 	tasks = [],
-	opts = {},
+	config = {},
 }: {
 	tasks?: Array<Task<TState, any, any>>;
-	opts?: Partial<PlannerOpts>;
+	config?: Partial<PlannerConfig>;
 }): Planner<TState> {
 	const taskIds = new Set<string>();
 	tasks.forEach((t) => {
@@ -301,13 +45,13 @@ function of<TState = any>({
 	});
 
 	return {
-		find(current: TState, target: Target<TState>) {
+		findPlan(current: TState, target: Target<TState>) {
 			const time = performance.now();
 			const res = findPlan({
 				current,
 				diff: Diff.of(current, target),
 				tasks,
-				trace: opts.trace,
+				trace: config.trace,
 			});
 			res.stats = { ...res.stats, time: performance.now() - time };
 			return res;

--- a/lib/planner/types.ts
+++ b/lib/planner/types.ts
@@ -1,0 +1,63 @@
+import { Action } from '../task';
+
+/**
+ * Stats about the planning process
+ */
+export interface PlanningStats {
+	/**
+	 * Number of iterations (tasks tested) in total
+	 */
+	iterations: number;
+
+	/**
+	 * Maximum search depth
+	 */
+	maxDepth: number;
+
+	/**
+	 * Total search time in ms
+	 */
+	time: number;
+}
+
+/**
+ * Result of the planning process
+ */
+export type PlanningResult<TState> =
+	| {
+			/**
+			 * Planning was successful
+			 */
+			success: true;
+			/**
+			 * The plan to get from the current state to the target state
+			 */
+			plan: Array<Action<TState>>;
+			/**
+			 * The expected state after applying the plan
+			 */
+			state: TState;
+			/**
+			 * Stats about the planning process
+			 */
+			stats: PlanningStats;
+	  }
+	| {
+			/**
+			 * Planning was not successful
+			 */
+			success: false;
+
+			/**
+			 * Stats about the planning process
+			 */
+			stats: PlanningStats;
+	  };
+
+export interface PlannerConfig {
+	/**
+	 * A function used by the planner to debug the search
+	 * for a plan. It defaults to a noop.
+	 */
+	trace: (...args: any[]) => void;
+}

--- a/lib/planner/utils.spec.ts
+++ b/lib/planner/utils.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from '~/tests';
-import { Task, NoEffect } from './task';
-import { Operation } from './operation';
+import { isTaskApplicable } from './utils';
+import { Task, NoEffect } from '../task';
+import { Operation } from '../operation';
 
-describe('Task', () => {
-	describe('isApplicable', () => {
-		it('accept matching paths', () => {
+describe('planner/utils', () => {
+	describe('isTaskApplicable', () => {
+		it('accept matching paths between a Task and an Operation', () => {
 			expect(
-				Task.isApplicable(
+				isTaskApplicable(
 					Task.of({ op: 'delete', path: '/a/b/c', effect: NoEffect }),
 					{
 						op: 'delete',
@@ -15,7 +16,7 @@ describe('Task', () => {
 				),
 			).to.be.true;
 			expect(
-				Task.isApplicable(
+				isTaskApplicable(
 					Task.of({ op: 'delete', path: '/a/:arg/c', effect: NoEffect }),
 					{
 						op: 'delete',
@@ -27,7 +28,7 @@ describe('Task', () => {
 
 		it('returns false if the operation does not match', () => {
 			expect(
-				Task.isApplicable(
+				isTaskApplicable(
 					Task.of({ op: 'create', path: '/a/b/c', effect: NoEffect }),
 					{
 						op: 'delete',
@@ -36,7 +37,7 @@ describe('Task', () => {
 				),
 			).to.be.false;
 			expect(
-				Task.isApplicable(
+				isTaskApplicable(
 					Task.of({ op: 'delete', path: '/a/:arg/c', effect: NoEffect }),
 					Operation.of<{ a: { b: { c: string } } }, '/a/b/c'>({
 						op: 'create',
@@ -47,33 +48,33 @@ describe('Task', () => {
 			).to.be.false;
 		});
 
-		it('reject paths referencing a different part of the object', () => {
+		it('reject paths referencing a different part of the state object', () => {
 			expect(
-				Task.isApplicable(Task.of({ path: '/a/b/c', effect: NoEffect }), {
+				isTaskApplicable(Task.of({ path: '/a/b/c', effect: NoEffect }), {
 					op: 'delete',
 					path: '/a/b',
 				}),
 			).to.be.false;
 			expect(
-				Task.isApplicable(Task.of({ path: '/a/:arg/c', effect: NoEffect }), {
+				isTaskApplicable(Task.of({ path: '/a/:arg/c', effect: NoEffect }), {
 					op: 'delete',
 					path: '/d/b/c',
 				}),
 			).to.be.false;
 			expect(
-				Task.isApplicable(Task.of({ path: '/a/:arg', effect: NoEffect }), {
+				isTaskApplicable(Task.of({ path: '/a/:arg', effect: NoEffect }), {
 					op: 'delete',
 					path: '/a',
 				}),
 			).to.be.false;
 			expect(
-				Task.isApplicable(Task.of({ path: '/:arg', method: () => [] }), {
+				isTaskApplicable(Task.of({ path: '/:arg', method: () => [] }), {
 					op: 'delete',
 					path: '/',
 				}),
 			).to.be.false;
 			expect(
-				Task.isApplicable(Task.of({ path: '/a', effect: NoEffect }), {
+				isTaskApplicable(Task.of({ path: '/a', effect: NoEffect }), {
 					op: 'delete',
 					path: '/b/c',
 				}),

--- a/lib/planner/utils.ts
+++ b/lib/planner/utils.ts
@@ -1,0 +1,36 @@
+import { Task } from '../task';
+import { TaskOp } from '../context';
+import { Path } from '../path';
+import { Operation } from '../operation';
+
+/**
+ * Identify if a task is applicable for a specific operation
+ *
+ * A task is applicable if the task operation as the operation op, and if the task path matches the operation
+ * path
+ */
+export function isTaskApplicable<
+	TState = any,
+	TPath extends Path = '/',
+	TOp extends TaskOp = 'update',
+>(t: Task<TState, TPath, TOp>, o: Operation<any, any>) {
+	if (t.op !== '*' && t.op !== o.op) {
+		return false;
+	}
+
+	const taskParts = Path.elems(t.path);
+	const opParts = Path.elems(o.path);
+
+	if (taskParts.length !== opParts.length) {
+		return false;
+	}
+
+	for (const tElem of taskParts) {
+		const oElem = opParts.shift();
+		if (!tElem.startsWith(':') && tElem !== oElem) {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build": "npm run clean && tsc --project tsconfig.release.json",
     "lint": "balena-lint --typescript lib tests",
     "lint-fix": "balena-lint --typescript --fix lib tests",
-    "test:node": "mocha --reporter spec lib/**/*.spec.ts --config tests/.mocharc.js",
+    "test:node": "mocha --reporter spec lib/*.spec.ts lib/**/*.spec.ts --config tests/.mocharc.js",
     "test:integration": "mocha --reporter spec tests/**/*.spec.ts --config tests/.mocharc.js",
     "test": "npm run build && npm run lint && npm run test:node",
     "test:compose": "docker compose -f docker-compose.yml -f docker-compose.test.yml up --build --remove-orphans --exit-code-from=sut ; npm run compose:down",

--- a/tests/composer/planner.ts
+++ b/tests/composer/planner.ts
@@ -6,5 +6,5 @@ import { fetch, install, remove, start, stop } from './tasks';
 
 export const planner = Planner.of<App>({
 	tasks: [fetch, install, start, stop, remove],
-	opts: { trace: console.trace },
+	config: { trace: console.trace },
 });

--- a/tests/composer/planning.spec.ts
+++ b/tests/composer/planning.spec.ts
@@ -11,7 +11,7 @@ describe('composer/planning', () => {
 			images: [],
 		};
 
-		const result = planner.find(app, {
+		const result = planner.findPlan(app, {
 			services: {
 				main: {
 					image: 'alpine:latest',
@@ -39,7 +39,7 @@ describe('composer/planning', () => {
 			images: [{ name: 'alpine:latest', imageId: '123' }],
 		};
 
-		const result = planner.find(app, {
+		const result = planner.findPlan(app, {
 			services: {
 				main: {
 					status: 'running',
@@ -73,7 +73,7 @@ describe('composer/planning', () => {
 			images: [{ name: 'alpine:latest', imageId: '123' }],
 		};
 
-		const result = planner.find(app, {
+		const result = planner.findPlan(app, {
 			services: {
 				main: {
 					status: 'stopped',
@@ -97,7 +97,7 @@ describe('composer/planning', () => {
 			images: [],
 		};
 
-		const result = planner.find(app, {
+		const result = planner.findPlan(app, {
 			services: {
 				main: {
 					status: 'stopped',
@@ -134,7 +134,7 @@ describe('composer/planning', () => {
 			images: [{ name: 'alpine:3.13', imageId: '123' }],
 		};
 
-		const result = planner.find(app, {
+		const result = planner.findPlan(app, {
 			services: {
 				main: {
 					status: 'running',
@@ -170,7 +170,7 @@ describe('composer/planning', () => {
 			images: [{ name: 'alpine:3.13', imageId: '123' }],
 		};
 
-		const result = planner.find(app, {
+		const result = planner.findPlan(app, {
 			services: {
 				main: {
 					status: 'running',
@@ -206,7 +206,7 @@ it('knows to recreate service if config has changed', () => {
 		images: [{ name: 'alpine:3.13', imageId: '123' }],
 	};
 
-	const result = planner.find(app, {
+	const result = planner.findPlan(app, {
 		services: {
 			main: {
 				status: 'running',

--- a/tests/orchestrator/planner.ts
+++ b/tests/orchestrator/planner.ts
@@ -32,5 +32,5 @@ export const planner = Planner.of<Device>({
 		removeRelease,
 		removeApp,
 	],
-	opts: { trace: console.trace },
+	config: { trace: console.trace },
 });

--- a/tests/orchestrator/planning.spec.ts
+++ b/tests/orchestrator/planning.spec.ts
@@ -14,7 +14,7 @@ describe('orchestrator/planning', () => {
 			images: [{ name: 'a0_main:r0' }],
 		};
 
-		const result = planner.find(device, {
+		const result = planner.findPlan(device, {
 			apps: {
 				a0: {
 					name: 'test-app',
@@ -63,7 +63,7 @@ describe('orchestrator/planning', () => {
 			images: [],
 		};
 
-		const result = planner.find(device, {
+		const result = planner.findPlan(device, {
 			apps: {
 				a0: {
 					name: 'test-app',
@@ -118,7 +118,7 @@ describe('orchestrator/planning', () => {
 			images: [{ name: 'a0_main:r0' }],
 		};
 
-		const result = planner.find(device, {
+		const result = planner.findPlan(device, {
 			apps: {
 				a0: {
 					name: 'test-app',
@@ -162,7 +162,7 @@ describe('orchestrator/planning', () => {
 			images: [],
 		};
 
-		const result = planner.find(device, {
+		const result = planner.findPlan(device, {
 			name: 'test',
 			uuid: 'd0',
 			apps: {
@@ -222,7 +222,7 @@ describe('orchestrator/planning', () => {
 			images: [{ name: 'a0_main:r0' }],
 		};
 
-		const result = planner.find(device, {
+		const result = planner.findPlan(device, {
 			name: 'test',
 			uuid: 'd0',
 			apps: {
@@ -281,7 +281,7 @@ describe('orchestrator/planning', () => {
 			images: [{ name: 'a0_main:r0' }],
 		};
 
-		const result = planner.find(device, {
+		const result = planner.findPlan(device, {
 			apps: {
 				a0: {
 					name: 'test-app',
@@ -349,7 +349,7 @@ describe('orchestrator/planning', () => {
 			images: [{ name: 'a0_main:r0' }],
 		};
 
-		const result = planner.find(device, {
+		const result = planner.findPlan(device, {
 			apps: {
 				a0: {
 					name: 'test-app',


### PR DESCRIPTION
This splits up the `planner.ts` module into multiple files under
`lib/planner`, it also renames some methods, properties for better readability, as well as removing duplicate code.

Change-type: patch