### PR TITLE
Allow action tasks to return an Observable

### DIFF
--- a/lib/observable.ts
+++ b/lib/observable.ts
@@ -113,6 +113,15 @@ function of<T>(
 	};
 }
 
+function is<T = any>(x: unknown): x is Observable<T> {
+	return (
+		x != null &&
+		(x as any).subscribe != null &&
+		typeof (x as any).subscribe === 'function'
+	);
+}
+
 export const Observable = {
 	of,
+	is,
 };

--- a/lib/task/instructions.ts
+++ b/lib/task/instructions.ts
@@ -1,3 +1,5 @@
+import { Observable } from '../observable';
+
 interface Instance<TState> {
 	/**
 	 * The instance id
@@ -29,7 +31,7 @@ export interface Action<TState = any> extends Instance<TState> {
 	/**
 	 * Run the action
 	 */
-	(s: TState): Promise<TState>;
+	(s: TState): Promise<TState> | Observable<TState>;
 }
 
 /** A method task that has been applied to a specific context */

--- a/lib/task/tasks.ts
+++ b/lib/task/tasks.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 
 import assert from '../assert';
 import { Context, ContextAsArgs, TaskOp } from '../context';
+import { Observable } from '../observable';
 import { Path } from '../path';
 
 import { Action, Instruction, Method } from './instructions';
@@ -55,9 +56,15 @@ export interface ActionTask<
 	effect(s: TState, c: Context<TState, TPath, TOp>): TState;
 
 	/**
-	 * The actual action the task performs
+	 * The actual action the task performs. The action may return an Observable
+	 * or a Promise. If the action returns an Observable,
+	 * the planner will wait for the observable to complete before continuing, but
+	 * use any state updates to communicate about state changes to its observers.
 	 */
-	action(s: TState, c: Context<TState, TPath, TOp>): Promise<TState>;
+	action(
+		s: TState,
+		c: Context<TState, TPath, TOp>,
+	): Promise<TState> | Observable<TState>;
 
 	/**
 	 * The task function grounds the task


### PR DESCRIPTION
This allow long running tasks (e.g. downloading a large file) to report intermediate progress of the operation (e.g. download progress) that the agent can report to its subscribers.

Change-type: patch