### PR TITLE
Improve planner loop detection

### DIFF
--- a/lib/agent.spec.ts
+++ b/lib/agent.spec.ts
@@ -39,11 +39,9 @@ describe('Agent', () => {
 		it('it allows to subscribe to the agent state', async () => {
 			const inc = Task.of({
 				condition: (state: number, { target }) => state < target,
-				// TODO: we need to fix the planner, the effect here really should return the next
-				// state instead of the target state here, however the planner only allows
-				// to insert instance of a task in the plan
-				effect: (_: number, { target }) => target,
+				effect: (state: number) => state + 1,
 				action: async (state: number) => state + 1,
+				description: 'increment',
 			});
 			const agent = Agent.of({
 				initial: 0,

--- a/lib/planner/index.ts
+++ b/lib/planner/index.ts
@@ -1,10 +1,14 @@
 import { Diff } from '../diff';
 import { Target } from '../target';
-import { Task } from '../task';
-import { findPlan } from './findPlan';
-import { PlannerConfig, PlanningResult } from './types';
+import { Action, Task } from '../task';
+import { PlanningFailure, PlanningSuccess, findPlan } from './findPlan';
+import { PlannerConfig } from './types';
 
 export * from './types';
+
+export type PlanningResult<TState> =
+	| (Omit<PlanningSuccess<TState>, 'plan'> & { plan: Array<Action<TState>> })
+	| PlanningFailure;
 
 export interface Planner<TState = any> {
 	/**
@@ -43,6 +47,9 @@ function of<TState = any>({
 				trace: config.trace,
 			});
 			res.stats = { ...res.stats, time: performance.now() - time };
+			if (res.success) {
+				return { ...res, plan: res.plan.map(([_, a]) => a) };
+			}
 			return res;
 		},
 	};

--- a/lib/planner/types.ts
+++ b/lib/planner/types.ts
@@ -1,5 +1,3 @@
-import { Action } from '../task';
-
 /**
  * Stats about the planning process
  */
@@ -19,40 +17,6 @@ export interface PlanningStats {
 	 */
 	time: number;
 }
-
-/**
- * Result of the planning process
- */
-export type PlanningResult<TState> =
-	| {
-			/**
-			 * Planning was successful
-			 */
-			success: true;
-			/**
-			 * The plan to get from the current state to the target state
-			 */
-			plan: Array<Action<TState>>;
-			/**
-			 * The expected state after applying the plan
-			 */
-			state: TState;
-			/**
-			 * Stats about the planning process
-			 */
-			stats: PlanningStats;
-	  }
-	| {
-			/**
-			 * Planning was not successful
-			 */
-			success: false;
-
-			/**
-			 * Stats about the planning process
-			 */
-			stats: PlanningStats;
-	  };
 
 export interface PlannerConfig {
 	/**


### PR DESCRIPTION
The planner would skip any action that was already added to the plan, however this would prevent repeat actions that modify the state incrementally. The planner now skips an action if it has been used before for the same state.

Change-type: patch