### PR TITLE
Expose planner API via mahler/planner

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,4 @@
 export * from './agent';
-export * from './planner';
 export * from './observable';
 export * from './sensor';
 export * from './task';

--- a/lib/planner/index.ts
+++ b/lib/planner/index.ts
@@ -2,9 +2,11 @@ import { Diff } from '../diff';
 import { Target } from '../target';
 import { Task } from '../task';
 import { findPlan } from './findPlan';
-import { PlannerConfig, Plan, Node } from './types';
+import { PlannerConfig } from './types';
+import { Plan, Node } from './plan';
 
 export * from './types';
+export * from './plan';
 
 export interface Planner<TState = any> {
 	/**

--- a/lib/planner/plan.ts
+++ b/lib/planner/plan.ts
@@ -1,0 +1,86 @@
+import { createHash } from 'crypto';
+
+import { Action } from '../task';
+import { PlanningStats } from './types';
+
+/**
+ * A node defines a specific step in a plan.
+ */
+export interface Node<TState> {
+	/**
+	 * Unique id for the node. This is calculated from the
+	 * action metadata and the current runtime state expected
+	 * by the planner. This is used for loop detection in the plan.
+	 */
+	readonly id: string;
+
+	/**
+	 * The action to execute
+	 */
+	readonly action: Action<TState, any, any>;
+
+	/**
+	 * The next step in the plan
+	 */
+	next: Node<TState> | null;
+}
+
+export type Plan<TState> =
+	| {
+			/**
+			 * A plan was found
+			 */
+			success: true;
+
+			/**
+			 * The initial step in the plan. If the start
+			 * node is null, that means the plan is empty.
+			 */
+			start: Node<TState> | null;
+
+			/**
+			 * The expected state at the end of the plan. This is
+			 * probably not useful for end users, but is useful to keep
+			 * track of intermediate steps in the planning process.
+			 */
+			state: TState;
+
+			/**
+			 * The resulting stats of the planning process
+			 */
+			stats: PlanningStats;
+	  }
+	| {
+			/**
+			 * A plan could not be found
+			 */
+			success: false;
+
+			/**
+			 * The resulting stats of the planning process
+			 */
+			stats: PlanningStats;
+	  };
+
+export const Node = {
+	of: <TState>(s: TState, a: Action<TState, any, any>): Node<TState> => {
+		// md5 should be good enough for this purpose
+		// and it's the fastest of the available options
+		const id = createHash('md5')
+			.update(
+				JSON.stringify({
+					id: a.id,
+					path: a.path,
+					state: s,
+					...(a.target && { target: a.target }),
+				}),
+			)
+			.digest('hex');
+
+		return {
+			id,
+			action: a,
+			next: null,
+		};
+	},
+};

--- a/lib/planner/types.ts
+++ b/lib/planner/types.ts
@@ -1,5 +1,3 @@
-import { Action } from '../task';
-
 /**
  * Stats about the planning process
  */
@@ -27,62 +25,3 @@ export interface PlannerConfig {
 	 */
 	trace: (...args: any[]) => void;
 }
-
-/**
- * A node defines a specific step in a plan.
- */
-export interface Node<TState> {
-	/**
-	 * Unique id for the node. This is calculated from the
-	 * action metadata and the current runtime state expected
-	 * by the planner. This is used for loop detection in the plan.
-	 */
-	readonly id: string;
-
-	/**
-	 * The action to execute
-	 */
-	readonly action: Action<TState, any, any>;
-
-	/**
-	 * The next step in the plan
-	 */
-	next: Node<TState> | null;
-}
-
-export type Plan<TState> =
-	| {
-			/**
-			 * A plan was found
-			 */
-			success: true;
-
-			/**
-			 * The initial step in the plan. If the start
-			 * node is null, that means the plan is empty.
-			 */
-			start: Node<TState> | null;
-
-			/**
-			 * The expected state at the end of the plan. This is
-			 * probably not useful for end users, but is useful to keep
-			 * track of intermediate steps in the planning process.
-			 */
-			state: TState;
-
-			/**
-			 * The resulting stats of the planning process
-			 */
-			stats: PlanningStats;
-	  }
-	| {
-			/**
-			 * A plan could not be found
-			 */
-			success: false;
-
-			/**
-			 * The resulting stats of the planning process
-			 */
-			stats: PlanningStats;
-	  };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "build/index.js",
   "exports": {
     ".": "./build/index.js",
-    "./testing": "./build/testing/index.js"
+    "./testing": "./build/testing/index.js",
+    "./planner": "./build/planner/index.js"
   },
   "types": "build/index.d.ts",
   "keywords": [

--- a/tests/composer/planner.ts
+++ b/tests/composer/planner.ts
@@ -1,4 +1,4 @@
-import { Planner } from 'mahler';
+import { Planner } from 'mahler/planner';
 import { console } from '~/test-utils';
 
 import { App } from './state';

--- a/tests/orchestrator/planner.ts
+++ b/tests/orchestrator/planner.ts
@@ -1,4 +1,4 @@
-import { Planner } from 'mahler';
+import { Planner } from 'mahler/planner';
 import { console } from '~/test-utils';
 
 import { Device } from './state';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,9 @@
 			"mahler/testing": [
 				"lib/testing/index.ts"
 			],
+			"mahler/planner": [
+				"lib/planner/index.ts"
+			],
 			"~/test-utils": [
 				"tests/index.ts"
 			]


### PR DESCRIPTION
Before the API was exposed at the top level `mahler` import. Using the `Planner` interface by itself should be generally rare and most likely limited to testing. Exposing the planner API via a namespace makes that more evident.

Change-type: minor