### PR TITLE
Use effects for actions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-	"extends": [
-		"./node_modules/@balena/lint/config/.eslintrc.js"
-	]
-}

--- a/lib/agent/index.ts
+++ b/lib/agent/index.ts
@@ -1,6 +1,6 @@
 import assert from '../assert';
 import { NullLogger } from '../logger';
-import { Observable, Subject } from '../observable';
+import { Subscribable, Subject } from '../observable';
 import { Planner } from '../planner';
 import { Sensor } from '../sensor';
 import { Target } from '../target';
@@ -10,7 +10,7 @@ import { AgentOpts, NotStarted, Result } from './types';
 
 export * from './types';
 
-export interface Agent<TState = any> extends Observable<TState> {
+export interface Agent<TState = any> extends Subscribable<TState> {
 	/**
 	 * Tells the agent to seek a new target.
 	 *

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,4 @@
 export * from './agent';
-export * from './observable';
 export * from './sensor';
 export * from './task';
 export * from './logger';

--- a/lib/observable.spec.ts
+++ b/lib/observable.spec.ts
@@ -1,0 +1,256 @@
+import { expect } from '~/test-utils';
+import { Observable } from './observable';
+
+import { setTimeout } from 'timers/promises';
+import { stub } from 'sinon';
+
+const interval = (period: number): Observable<number> => {
+	return Observable.from(
+		(async function* () {
+			let i = 0;
+			while (true) {
+				await setTimeout(period);
+				yield i++;
+			}
+		})(),
+	);
+};
+
+describe('Observable', () => {
+	it('creates observables from promises', async () => {
+		const o = Observable.from(Promise.resolve(42));
+
+		// Add a subscriber
+		const next = stub();
+
+		const promise = new Promise<void>((resolve, reject) => {
+			const subscriber = o.subscribe({
+				next,
+				error: reject,
+				complete: () => {
+					resolve();
+					subscriber.unsubscribe();
+				},
+			});
+		});
+		await promise;
+		expect(next).to.have.been.calledOnce;
+		expect(next).to.have.been.calledWith(42);
+	});
+
+	it('creates observables from values', async () => {
+		const o = Observable.of(42);
+
+		// Add a subscriber
+		const next = stub();
+
+		const promise = new Promise<void>((resolve, reject) => {
+			const subscriber = o.subscribe({
+				next,
+				error: reject,
+				complete: () => {
+					resolve();
+					subscriber.unsubscribe();
+				},
+			});
+		});
+		await promise;
+		expect(next).to.have.been.calledOnce;
+		expect(next).to.have.been.calledWith(42);
+	});
+
+	it('only starts reading values when a subscriber is added', async () => {
+		const read = stub();
+		const o = interval(10).map(read);
+
+		// The sensor function should not be called before a subscriber is added
+		expect(read).to.not.have.been.called;
+
+		// Add a subscriber
+		const next = stub();
+		const subscriber = o.subscribe(next);
+
+		await setTimeout(39);
+
+		// Only now the sensor function should be called
+		expect(read).to.have.been.calledThrice;
+		expect(next).to.have.been.calledThrice;
+
+		subscriber.unsubscribe();
+	});
+
+	it('it returns a stream of values', async () => {
+		const o = interval(10);
+
+		// Add a subscriber
+		const next = stub();
+		const subscriber = o.subscribe(next);
+
+		await setTimeout(39);
+
+		// Only now the sensor function should be called
+		expect(next).to.have.been.calledThrice;
+		expect(next).to.have.been.calledWith(0);
+		expect(next).to.have.been.calledWith(1);
+		expect(next).to.have.been.calledWith(2);
+
+		subscriber.unsubscribe();
+
+		const next2 = stub();
+
+		// Testing unsubcribe
+		next.reset();
+		const subscriber2 = o.subscribe(next2);
+		await setTimeout(39);
+
+		expect(next2).to.have.been.calledThrice;
+		expect(next2).to.have.been.calledWith(4);
+		expect(next2).to.have.been.calledWith(5);
+		expect(next2).to.have.been.calledWith(6);
+		expect(next).to.not.have.been.called;
+
+		subscriber2.unsubscribe();
+	});
+
+	it('it shares values between subscribers', async () => {
+		// The current implementation makes it so values
+		// produced by async generators will be shared by
+		// multiple observers, which is probably not what we
+		// want, but it allows for a simpler implementation
+		const o = interval(10);
+
+		// Add a subscriber
+		const next = stub();
+		const next2 = stub();
+		const subscriber = o.subscribe(next);
+		const subscriber2 = o.subscribe(next2);
+
+		await setTimeout(45);
+
+		// Only now the sensor function should be called
+		expect(next).to.have.been.calledTwice;
+		expect(next2).to.have.been.calledTwice;
+		expect(next).to.have.been.calledWith(0);
+		expect(next2).to.have.been.calledWith(1);
+		expect(next).to.have.been.calledWith(2);
+		expect(next2).to.have.been.calledWith(3);
+
+		subscriber.unsubscribe();
+		subscriber2.unsubscribe();
+	});
+
+	it('it allows mapping over values', async () => {
+		const o = interval(10).map((x) => x * 2);
+
+		// Add a subscriber
+		const next = stub();
+		const subscriber = o.subscribe(next);
+
+		await setTimeout(39);
+
+		// Only now the sensor function should be called
+		expect(next).to.have.been.calledThrice;
+		expect(next).to.have.been.calledWith(0);
+		expect(next).to.have.been.calledWith(2);
+		expect(next).to.have.been.calledWith(4);
+
+		subscriber.unsubscribe();
+	});
+
+	it('it allows to merge observables', async () => {
+		const letters = Observable.of('a', 'b', 'c');
+		const o = letters.flatMap((x) => interval(10).map((y) => x + y));
+
+		// Add a subscriber
+		const next = stub();
+		const subscriber = o.subscribe(next);
+
+		await setTimeout(55);
+
+		// Only now the sensor function should be called
+		expect(next).to.have.been.calledWith('a0');
+		expect(next).to.have.been.calledWith('a1');
+		expect(next).to.have.been.calledWith('a2');
+		expect(next).to.have.been.calledWith('b0');
+		expect(next).to.have.been.calledWith('b1');
+
+		subscriber.unsubscribe();
+	});
+
+	it('it accepts generators returning values', async () => {
+		const letters = Observable.from(
+			(function* () {
+				yield 'a';
+				yield 'b';
+				return 'c';
+			})(),
+		);
+
+		// Add a subscriber
+		const next = stub();
+
+		const promise = new Promise<void>((resolve, reject) => {
+			const subscriber = letters.subscribe({
+				next,
+				error: reject,
+				complete: () => {
+					resolve();
+					subscriber.unsubscribe();
+				},
+			});
+		});
+		await promise;
+		expect(next).to.have.been.calledThrice;
+		expect(next).to.have.been.calledWith('a');
+		expect(next).to.have.been.calledWith('b');
+		expect(next).to.have.been.calledWith('c');
+	});
+
+	it('it propagates errors', async () => {
+		const letters = Observable.from(
+			(function* () {
+				yield 'a';
+				yield 'b';
+				throw new Error('test');
+			})(),
+		);
+
+		// Add a subscriber
+		const next = stub();
+
+		const promise = new Promise<void>((resolve, reject) => {
+			const subscriber = letters.subscribe({
+				next,
+				error: reject,
+				complete: () => {
+					resolve();
+					subscriber.unsubscribe();
+				},
+			});
+		});
+		await expect(promise).to.be.rejected;
+		expect(next).to.have.been.calledTwice;
+	});
+
+	it('it ignores the error if no error handler is provided', async () => {
+		const letters = Observable.from(
+			(function* () {
+				yield 'a';
+				yield 'b';
+				throw new Error('test');
+			})(),
+		);
+
+		const next = stub();
+		const rejection = stub();
+
+		// This will produce an unhandled rejection
+		process.once('unhandledRejection', rejection);
+
+		const subscriber = letters.subscribe(next);
+		await setTimeout(10);
+		expect(next).to.have.been.calledTwice;
+		expect(rejection).to.have.been.called;
+		subscriber.unsubscribe();
+	});
+});

--- a/lib/sensor.ts
+++ b/lib/sensor.ts
@@ -1,12 +1,42 @@
-import { Observable, Observer } from './observable';
+import { Observable, Observer, Subject } from './observable';
 
 export { Subscription } from './observable';
 
-export type Sensor<T> = Observable<(s: T) => T>;
-export type Subscriber<T> = Observer<(s: T) => T>;
+type SensorOutput<T> = (s: T) => T;
+export type Sensor<T> = Observable<SensorOutput<T>>;
+export type Subscriber<T> = Observer<SensorOutput<T>>;
 
 export const Sensor = {
 	of: <T>(
 		sensor: (subscriber: Subscriber<T>) => void | Promise<void>,
-	): Sensor<T> => Observable.of(sensor),
+	): Sensor<T> => {
+		const subject = new Subject<SensorOutput<T>>();
+
+		let running = false;
+		return Observable.from({
+			subscribe(next) {
+				const subscription = subject.subscribe(next);
+
+				// Now that we have subscribers we start the observable
+				if (!running) {
+					Promise.resolve(sensor(subject))
+						.then(() => {
+							// Notify the proxy of the observable completion
+							subject.complete();
+						})
+						.catch((e) => {
+							// Notify subscriber of uncaught errors on the observable
+							subject.error(e);
+						})
+						.finally(() => {
+							// The observable will restart when a new subscriber is added
+							running = false;
+						});
+					running = true;
+				}
+
+				return subscription;
+			},
+		});
+	},
 };

--- a/lib/task/effect.spec.ts
+++ b/lib/task/effect.spec.ts
@@ -1,0 +1,91 @@
+import { expect } from '~/test-utils';
+import { Effect, IO } from './effect';
+
+import { stub } from 'sinon';
+
+describe('Effect', () => {
+	it('allows chaining calculations', () => {
+		const effect = Effect.of(0).map((x) => x + 1);
+		expect(effect()).to.equal(1);
+	});
+
+	it('allows a sync and async executions', async () => {
+		const effect = Effect.of(0)
+			.map((x) => x + 1)
+			.flatMap((x) =>
+				Effect.from(
+					async () => x + 2,
+					() => x + 1,
+				),
+			)
+			.flatMap((x) =>
+				Effect.from(
+					async () => x + 1,
+					() => x + 1,
+				),
+			);
+		expect(effect()).to.equal(3);
+		expect(await effect).to.equal(4);
+	});
+
+	it('propagates errors in a promise', async () => {
+		const effect = Effect.of(0)
+			.map((x) => x + 1)
+			.flatMap((x) =>
+				Effect.from(
+					async () => {
+						if (x < 2) {
+							throw new Error('x is too small');
+						}
+						// This will never be reached
+						return x + 2;
+					},
+					() => x + 1,
+				),
+			)
+			.flatMap((x) =>
+				Effect.from(
+					async () => x + 1,
+					() => x + 1,
+				),
+			);
+		expect(effect()).to.equal(3);
+		await expect(effect).to.be.rejected;
+	});
+});
+
+it('allows using an async generator as IO', async () => {
+	const effect = Effect.of(0)
+		.map((x) => x + 1)
+		.flatMap((x) =>
+			IO(
+				async function* () {
+					yield x + 1;
+					yield x + 2;
+				},
+				() => x + 1,
+			),
+		)
+		.map((x) => x + 1);
+
+	const next = stub();
+
+	// Create a new promise to wait for the effect to
+	// finish
+	const promise = new Promise<void>((resolve, reject) => {
+		const subscriber = effect.subscribe({
+			next,
+			error: reject,
+			complete: () => {
+				resolve();
+				subscriber.unsubscribe();
+			},
+		});
+	});
+	await promise;
+	expect(effect()).to.equal(3);
+	expect(next).to.have.been.calledTwice;
+	expect(next).to.have.been.calledWith(3);
+	expect(next).to.have.been.calledWith(4);
+	expect(await effect).to.equal(4);
+});

--- a/lib/task/effect.ts
+++ b/lib/task/effect.ts
@@ -1,0 +1,180 @@
+import { Observable, Subscribable, Next, Observer } from '../observable';
+
+type AsyncReturn<T> = Promise<T> | AsyncGenerator<T, T | void, void>;
+type Async<T> = () => AsyncReturn<T>;
+type Sync<T> = () => T;
+
+type LazyObservable<T> = () => Observable<T>;
+
+/**
+ * The Effect type combines a sync and async computations into a single
+ * type.
+ *
+ * The sync computation is a pure function returning a value of type T.
+ * The async computation is a side effect, a function that performs a side effect
+ * and returns a value of type T.
+ *
+ * For IO operations, a pure, synchronous computation needs to be provided as
+ * a fallback. The pure side is used to test how the side effect
+ * function will change the state of the world, without the need
+ * to actually perform IO.
+ *
+ * An effect doesn't need to perform IO. Effects can be used to encode pure computations
+ * where both the sync and async computations are pure.
+ *
+ * Effects can be chained using map and flatMap. Combinators functions can also be used
+ * to combine effects. The pipe function can be used to chain effects in a more declarative
+ * way.
+ *
+ * An Effect can be called as a function or be awaited as a promise. The function is used to perform
+ * the sync computation, while awaiting will perform the async computation.
+ *
+ * Example: a function that reads a number from hardware
+ * ```ts
+ * import {Effect, IO} from './effects';
+ *
+ * const readNumber = (expected: number): Effect<string> =>
+ *  // This reads a number from hardware, but returns an expected
+ *  // value as a mock
+ * 	IO(async () => await readFromHW(), expected)
+ *
+ * const eff = readNumber(0);
+ * console.log(eff()); // 0
+ * console.log(await eff); // 42
+ *
+ * // Combine effects
+ * const eff2 = Effect.of(0).flatMap(readNumber).map(x => x + 1);
+ *
+ * console.log(eff()); // 1
+ * console.log(await eff); // 43
+ * ```
+ */
+export interface Effect<T> extends Subscribable<T> {
+	/**
+	 * Execute the effect synchronously
+	 */
+	(): T;
+	/**
+	 * Allow to use the effect as a promise and apply the full
+	 * asynchronous part of the operation
+	 */
+	then<U = T, N = never>(
+		resolved?: (t: T) => U | PromiseLike<U>,
+		rejected?: (reason: any) => N | PromiseLike<N>,
+	): PromiseLike<U | N>;
+	/**
+	 * The map function transforms the effect by applying a function
+	 * to the internal value.
+	 */
+	map<U>(f: (t: T) => U): Effect<U>;
+	/**
+	 * The flatMap function allows to chain effects. The function
+	 * passed to flatMap is applied to the internal value, and
+	 * the result is returned as a new effect.
+	 */
+	flatMap<U>(f: (t: T) => Effect<U>): Effect<U>;
+}
+
+/**
+ * Builds an effect from a sync and async computation. The async computation is
+ * encoded as an observable, which allows an effect to be subscribed
+ */
+function build(obs: LazyObservable<void>, sync?: Sync<void>): Effect<void>;
+function build<T>(obs: LazyObservable<T>, sync: Sync<T>): Effect<T>;
+function build<T>(
+	obs: LazyObservable<T>,
+	sync = (() => {
+		/* noop */
+	}) as () => T,
+): Effect<T> {
+	return Object.assign(sync, {
+		subscribe(next: Next<T> | Observer<T>) {
+			return obs().subscribe(next);
+		},
+		then<U = T, N = never>(
+			onresolve?: (t: T) => U | PromiseLike<U>,
+			onreject?: (reason: any) => N | PromiseLike<N>,
+		): PromiseLike<U | N> {
+			return new Promise<T>((resolve, reject) => {
+				let res: T;
+				obs().subscribe({
+					next(t) {
+						res = t;
+					},
+					error: reject,
+					complete: () => resolve(res),
+				});
+			}).then(onresolve, onreject);
+		},
+		map<U>(fu: (t: T) => U): Effect<U> {
+			return build<U>(
+				() => obs().map(fu),
+				() => fu(sync()),
+			);
+		},
+		flatMap<U>(fu: (t: T) => Effect<U>): Effect<U> {
+			return build<U>(() => obs().flatMap((t) => fu(t)), fu(sync()));
+		},
+	});
+}
+
+/**
+ * Build an effect with an async and a sync computation
+ *
+ * The async part of the effect is either an async function or a function
+ * returning an async generator. If a generator is used, then the yielded
+ * values from the effect will be provided to subscribers of the effect.
+ *
+ * The synchronous function is mandatory except for effects returning
+ * `void`
+ */
+function from(async: Async<void>, sync: Sync<void>): Effect<void>;
+function from<T>(async: Async<T>, sync: Sync<T>): Effect<T>;
+function from<T>(async: Async<T>, sync?: Sync<T>): Effect<T> {
+	return build(() => Observable.from(async()), sync!);
+}
+
+/**
+ * Creates a pure effect, from a given synchronous operation.
+ */
+function pure<T>(f: Sync<T>): Effect<T> {
+	return from(async () => f(), f);
+}
+
+/**
+ * Creates a new effect from a value. It basically "lifts" the value
+ * to the Effects domain.
+ */
+function of<T>(t: T): Effect<T> {
+	return pure(() => t);
+}
+
+/**
+ * Create a side effect from an async and sync sides
+ * value.
+ */
+export const IO = from;
+
+/**
+ * Type guard to check if a given value is an effect
+ */
+function is<T>(x: unknown): x is Effect<T> {
+	return (
+		x != null &&
+		typeof x === 'function' &&
+		typeof (x as any).then === 'function' &&
+		typeof (x as any).map === 'function'
+	);
+}
+
+export const Effect = {
+	of,
+	from,
+	is,
+	map<T, U>(et: Effect<T>, ef: (t: T) => U): Effect<U> {
+		return et.map(ef);
+	},
+	flatMap<T, U>(et: Effect<T>, ef: (t: T) => Effect<U>): Effect<U> {
+		return et.flatMap(ef);
+	},
+};

--- a/lib/task/helpers.ts
+++ b/lib/task/helpers.ts
@@ -1,3 +1,4 @@
+import { Effect } from './effect';
 import { Context, TaskOp } from '../context';
 
 import { Path } from '../path';
@@ -17,7 +18,9 @@ type PureTaskProps<
 	TPath extends Path = '/',
 	TOp extends TaskOp = 'update',
 > = Partial<Omit<ActionTask<TState, TPath, TOp>, 'effect' | 'action' | 'op'>> &
-	Pick<ActionTask<TState, TPath, TOp>, 'effect' | 'op'>;
+	Pick<ActionTask<TState, TPath, TOp>, 'op'> & {
+		effect(s: TState, c: Context<TState, TPath, TOp>): TState;
+	};
 
 /**
  * A pure task is a task that has no side effects,
@@ -122,13 +125,12 @@ export function NoOp<
 >(ctx: Context<TState, TPath, TOp>): Action<TState> {
 	const id = 'noop';
 
-	return Object.assign((s: TState) => Promise.resolve(s), {
+	return Object.assign((s: TState) => Effect.of(s), {
 		_tag: 'action' as const,
 		id,
 		path: ctx.path as any,
 		target: (ctx as any).target,
 		description: 'no-op',
 		condition: () => true,
-		effect: (s: TState) => s,
 	});
 }

--- a/lib/task/instructions.ts
+++ b/lib/task/instructions.ts
@@ -1,4 +1,4 @@
-import { Observable } from '../observable';
+import { Effect } from './effect';
 import { Path } from '../path';
 import { TaskOp, Context } from '../context';
 
@@ -40,16 +40,9 @@ export interface Action<
 	readonly _tag: 'action';
 
 	/**
-	 * The effect on the state that the action
-	 * provides. If the effect returns none, then the task is not applicable
-	 * on the current state
-	 */
-	effect(s: TState): TState;
-
-	/**
 	 * Run the action
 	 */
-	(s: TState): Promise<TState> | Observable<TState>;
+	(s: TState): Effect<TState>;
 }
 
 /** A method task that has been applied to a specific context */
@@ -93,8 +86,6 @@ function isAction<TState = any>(
 	return (
 		(t as any).condition != null &&
 		typeof (t as any).condition === 'function' &&
-		(t as any).effect != null &&
-		typeof (t as any).effect === 'function' &&
 		typeof t === 'function' &&
 		(t as any)._tag === 'action'
 	);

--- a/lib/testing/mermaid.spec.ts
+++ b/lib/testing/mermaid.spec.ts
@@ -365,50 +365,50 @@ describe('Mermaid', () => {
 				start(( ))
 				start -.- d0{ }
 				d0 -.- 588eea4[["increment counters"]]
-				588eea4 -.- de739bb("a + 1")
-				588eea4 -.- 5716ae8("b + 1")
-				de739bb -.- j17bab65
-				5716ae8 -.- j17bab65
-				j17bab65(( ))
-				j17bab65 -.- d1{ }
+				588eea4 -.- 0874e9a("a + 1")
+				588eea4 -.- ef61a3a("b + 1")
+				0874e9a -.- jf4ad1f3
+				ef61a3a -.- jf4ad1f3
+				jf4ad1f3(( ))
+				jf4ad1f3 -.- d1{ }
 				d1 -.- c5108a8[["increment counters"]]
-				c5108a8 -.- eef8f5d("a + 1")
-				c5108a8 -.- 1021e18("b + 1")
-				eef8f5d -.- j0270df9
-				1021e18 -.- j0270df9
-				j0270df9(( ))
-				j0270df9 -.- d2{ }
+				c5108a8 -.- 99bf28d("a + 1")
+				c5108a8 -.- bd9e0b4("b + 1")
+				99bf28d -.- j9ed3ea0
+				bd9e0b4 -.- j9ed3ea0
+				j9ed3ea0(( ))
+				j9ed3ea0 -.- d2{ }
 				d2 -.- ee9e70b[["increment counters"]]
 				ee9e70b -.- ee9e70b-err[ ]
 				ee9e70b-err:::error
-				d2 -.- 2627161("a + 1")
-				2627161 -.- stop(( ))
+				d2 -.- cea1c98("a + 1")
+				cea1c98 -.- stop(( ))
 				stop:::finish
 				classDef finish stroke:#000,fill:#000
 				start:::selected
-				start --> fj17bab65(( ))
-				fj17bab65:::selected
-				fj17bab65 --> de739bb
-				de739bb:::selected
-				fj17bab65 --> 5716ae8
-				5716ae8:::selected
-				j17bab65(( ))
-				de739bb --> j17bab65
-				5716ae8 --> j17bab65
-				j17bab65:::selected
-				j17bab65 --> fj0270df9(( ))
-				fj0270df9:::selected
-				fj0270df9 --> eef8f5d
-				eef8f5d:::selected
-				fj0270df9 --> 1021e18
-				1021e18:::selected
-				j0270df9(( ))
-				eef8f5d --> j0270df9
-				1021e18 --> j0270df9
-				j0270df9:::selected
-				j0270df9 --> 2627161
-				2627161:::selected
-				2627161 --> stop
+				start --> fjf4ad1f3(( ))
+				fjf4ad1f3:::selected
+				fjf4ad1f3 --> 0874e9a
+				0874e9a:::selected
+				fjf4ad1f3 --> ef61a3a
+				ef61a3a:::selected
+				jf4ad1f3(( ))
+				0874e9a --> jf4ad1f3
+				ef61a3a --> jf4ad1f3
+				jf4ad1f3:::selected
+				jf4ad1f3 --> fj9ed3ea0(( ))
+				fj9ed3ea0:::selected
+				fj9ed3ea0 --> 99bf28d
+				99bf28d:::selected
+				fj9ed3ea0 --> bd9e0b4
+				bd9e0b4:::selected
+				j9ed3ea0(( ))
+				99bf28d --> j9ed3ea0
+				bd9e0b4 --> j9ed3ea0
+				j9ed3ea0:::selected
+				j9ed3ea0 --> cea1c98
+				cea1c98:::selected
+				cea1c98 --> stop
 				classDef error stroke:#f00
 				classDef selected stroke:#0f0
 			`,
@@ -458,43 +458,43 @@ describe('Mermaid', () => {
 				start -.- d0{ }
 				d0 -.- 2396eea[["increment counters"]]
 				2396eea -.- 682aa0e[["increase 'a'"]]
-				682aa0e -.- 4b66884("a + 1")
-				4b66884 -.- 29aedf2("a + 1")
+				682aa0e -.- f900ff9("a + 1")
+				f900ff9 -.- 00e5bb0("a + 1")
 				2396eea -.- 5dd218c[["increase 'b'"]]
-				5dd218c -.- aafffea("b + 1")
-				aafffea -.- 17593a3("b + 1")
-				29aedf2 -.- j0270df9
-				17593a3 -.- j0270df9
-				j0270df9(( ))
-				j0270df9 -.- d1{ }
+				5dd218c -.- 22ef581("b + 1")
+				22ef581 -.- d11a32a("b + 1")
+				00e5bb0 -.- j9ed3ea0
+				d11a32a -.- j9ed3ea0
+				j9ed3ea0(( ))
+				j9ed3ea0 -.- d1{ }
 				d1 -.- 7de2726[["increment counters"]]
 				7de2726 -.- 7de2726-err[ ]
 				7de2726-err:::error
 				d1 -.- 976345d[["increase 'a'"]]
 				976345d -.- 976345d-err[ ]
 				976345d-err:::error
-				d1 -.- eb463ce("a + 1")
-				eb463ce -.- stop(( ))
+				d1 -.- 2f364fb("a + 1")
+				2f364fb -.- stop(( ))
 				stop:::finish
 				classDef finish stroke:#000,fill:#000
 				start:::selected
-				start --> fj17bab65(( ))
-				fj17bab65:::selected
-				fj17bab65 --> 4b66884
-				4b66884:::selected
-				4b66884 --> 29aedf2
-				29aedf2:::selected
-				fj17bab65 --> aafffea
-				aafffea:::selected
-				aafffea --> 17593a3
-				17593a3:::selected
-				j17bab65(( ))
-				29aedf2 --> j17bab65
-				17593a3 --> j17bab65
-				j17bab65:::selected
-				j17bab65 --> eb463ce
-				eb463ce:::selected
-				eb463ce --> stop
+				start --> fjf4ad1f3(( ))
+				fjf4ad1f3:::selected
+				fjf4ad1f3 --> f900ff9
+				f900ff9:::selected
+				f900ff9 --> 00e5bb0
+				00e5bb0:::selected
+				fjf4ad1f3 --> 22ef581
+				22ef581:::selected
+				22ef581 --> d11a32a
+				d11a32a:::selected
+				jf4ad1f3(( ))
+				00e5bb0 --> jf4ad1f3
+				d11a32a --> jf4ad1f3
+				jf4ad1f3:::selected
+				jf4ad1f3 --> 2f364fb
+				2f364fb:::selected
+				2f364fb --> stop
 				classDef error stroke:#f00
 				classDef selected stroke:#0f0
 			`,
@@ -575,26 +575,26 @@ describe('Mermaid', () => {
 				d0 -.- 16c4cee[["chunk"]]
 				16c4cee -.- 85de134[["increment multiple"]]
 				85de134 -.- f086833[["a + 2"]]
-				f086833 -.- 55f3eb4("a++")
-				55f3eb4 -.- c49ebf7("a++")
+				f086833 -.- b97653c("a++")
+				b97653c -.- fdd46f5("a++")
 				85de134 -.- 491551c[["b + 2"]]
-				491551c -.- 497f947("b++")
-				497f947 -.- f401546("b++")
+				491551c -.- 76d9b13("b++")
+				76d9b13 -.- 0d8a6c4("b++")
 				16c4cee -.- 14b5abe[["increment multiple"]]
 				14b5abe -.- a6594ae[["c + 2"]]
-				a6594ae -.- 7932f99("c++")
-				7932f99 -.- 6f42d9e("c++")
+				a6594ae -.- fb528c3("c++")
+				fb528c3 -.- d7c9a30("c++")
 				14b5abe -.- 9a04ffd[["d + 2"]]
-				9a04ffd -.- d8ec9ff("d++")
-				d8ec9ff -.- 9e0f26a("d++")
-				c49ebf7 -.- j7f6fe40
-				f401546 -.- j7f6fe40
-				j7f6fe40(( )) -.- 4d89b9e
-				6f42d9e -.- jad26c69
-				9e0f26a -.- jad26c69
-				jad26c69(( )) -.- 4d89b9e
-				4d89b9e(( ))
-				4d89b9e -.- d1{ }
+				9a04ffd -.- b0c761f("d++")
+				b0c761f -.- d970700("d++")
+				fdd46f5 -.- jef318f8
+				0d8a6c4 -.- jef318f8
+				jef318f8(( )) -.- 25e807e
+				d7c9a30 -.- j902d46d
+				d970700 -.- j902d46d
+				j902d46d(( )) -.- 25e807e
+				25e807e(( ))
+				25e807e -.- d1{ }
 				d1 -.- cb79260[["chunk"]]
 				cb79260 -.- cb79260-err[ ]
 				cb79260-err:::error
@@ -604,48 +604,48 @@ describe('Mermaid', () => {
 				d1 -.- 8923404[["a + 2"]]
 				8923404 -.- 8923404-err[ ]
 				8923404-err:::error
-				d1 -.- 4664fc1("a++")
-				4664fc1 -.- stop(( ))
+				d1 -.- 7a51307("a++")
+				7a51307 -.- stop(( ))
 				stop:::finish
 				classDef finish stroke:#000,fill:#000
 				start:::selected
-				start --> ffbcbfff(( ))
-				ffbcbfff:::selected
-				ffbcbfff --> fj405808e(( ))
-				fj405808e:::selected
-				fj405808e --> 55f3eb4
-				55f3eb4:::selected
-				55f3eb4 --> c49ebf7
-				c49ebf7:::selected
-				fj405808e --> 497f947
-				497f947:::selected
-				497f947 --> f401546
-				f401546:::selected
-				j405808e(( ))
-				c49ebf7 --> j405808e
-				f401546 --> j405808e
-				j405808e:::selected
-				ffbcbfff --> fj6c9e279(( ))
-				fj6c9e279:::selected
-				fj6c9e279 --> 7932f99
-				7932f99:::selected
-				7932f99 --> 6f42d9e
-				6f42d9e:::selected
-				fj6c9e279 --> d8ec9ff
-				d8ec9ff:::selected
-				d8ec9ff --> 9e0f26a
-				9e0f26a:::selected
-				j6c9e279(( ))
-				6f42d9e --> j6c9e279
-				9e0f26a --> j6c9e279
-				j6c9e279:::selected
-				fbcbfff(( ))
-				j405808e --> fbcbfff
-				j6c9e279 --> fbcbfff
-				fbcbfff:::selected
-				fbcbfff --> 4664fc1
-				4664fc1:::selected
-				4664fc1 --> stop
+				start --> f3a3585e(( ))
+				f3a3585e:::selected
+				f3a3585e --> fjb462b59(( ))
+				fjb462b59:::selected
+				fjb462b59 --> b97653c
+				b97653c:::selected
+				b97653c --> fdd46f5
+				fdd46f5:::selected
+				fjb462b59 --> 76d9b13
+				76d9b13:::selected
+				76d9b13 --> 0d8a6c4
+				0d8a6c4:::selected
+				jb462b59(( ))
+				fdd46f5 --> jb462b59
+				0d8a6c4 --> jb462b59
+				jb462b59:::selected
+				f3a3585e --> fj47a9bc7(( ))
+				fj47a9bc7:::selected
+				fj47a9bc7 --> fb528c3
+				fb528c3:::selected
+				fb528c3 --> d7c9a30
+				d7c9a30:::selected
+				fj47a9bc7 --> b0c761f
+				b0c761f:::selected
+				b0c761f --> d970700
+				d970700:::selected
+				j47a9bc7(( ))
+				d7c9a30 --> j47a9bc7
+				d970700 --> j47a9bc7
+				j47a9bc7:::selected
+				3a3585e(( ))
+				jb462b59 --> 3a3585e
+				j47a9bc7 --> 3a3585e
+				3a3585e:::selected
+				3a3585e --> 7a51307
+				7a51307:::selected
+				7a51307 --> stop
 				classDef error stroke:#f00
 				classDef selected stroke:#0f0
 			`,
@@ -694,30 +694,30 @@ describe('Mermaid', () => {
 				start(( ))
 				start -.- d0{ }
 				d0 -.- 817288c[["increment counters"]]
-				817288c -.- 1ebf911("a + 1")
-				1ebf911 -.- 29aedf2("a + 1")
-				29aedf2 -.- 2525149("b + 1")
-				2525149 -.- 17593a3("b + 1")
-				17593a3 -.- d1{ }
+				817288c -.- 570ec53("a + 1")
+				570ec53 -.- 00e5bb0("a + 1")
+				00e5bb0 -.- 78cc211("b + 1")
+				78cc211 -.- d11a32a("b + 1")
+				d11a32a -.- d1{ }
 				d1 -.- 4b2ca33[["increment counters"]]
 				4b2ca33 -.- 4b2ca33-err[ ]
 				4b2ca33-err:::error
-				d1 -.- eb463ce("a + 1")
-				eb463ce -.- stop(( ))
+				d1 -.- 2f364fb("a + 1")
+				2f364fb -.- stop(( ))
 				stop:::finish
 				classDef finish stroke:#000,fill:#000
 				start:::selected
-				start --> 1ebf911
-				1ebf911:::selected
-				1ebf911 --> 29aedf2
-				29aedf2:::selected
-				29aedf2 --> 2525149
-				2525149:::selected
-				2525149 --> 17593a3
-				17593a3:::selected
-				17593a3 --> eb463ce
-				eb463ce:::selected
-				eb463ce --> stop
+				start --> 570ec53
+				570ec53:::selected
+				570ec53 --> 00e5bb0
+				00e5bb0:::selected
+				00e5bb0 --> 78cc211
+				78cc211:::selected
+				78cc211 --> d11a32a
+				d11a32a:::selected
+				d11a32a --> 2f364fb
+				2f364fb:::selected
+				2f364fb --> stop
 				classDef error stroke:#f00
 				classDef selected stroke:#0f0
 			`,


### PR DESCRIPTION
This PR introduces the `Effect` type to deal with asynchronous computations performed by actions returned from primitive tasks. 

The `Effect` type is a mix between a promise, a function and an
observable. It provides a way to combine an async computation with a
sync version which "simulates" the effect that the async computation
will have on the underlying system. These types are also composable via
`map` and `flatMap`, which would allow building more complex effects
from simpler ones, however this is outside the scope of the current PR
(see PR #33 for a use of those ideas).

This PR changes the `Action` type to return effects instead of a Promise
 which makes all actions observable by default, while keeping the action result
awaitable. This change is compatible with the existing API

Change-type: minor