### PR TITLE
Make task action default to the value of the effect

### DIFF
--- a/lib/task/tasks.ts
+++ b/lib/task/tasks.ts
@@ -267,12 +267,9 @@ function of<
 	// Check that the path is valid
 	Path.assert(path);
 
-	const prefix =
-		typeof (task as any).method === 'function'
-			? '[method] '
-			: typeof (task as any).parallel === 'function'
-			? '[parallel] '
-			: '';
+	const prefix = typeof (task as any).method === 'function' ? '[method] ' : '';
+
+	const { effect = (s: TState) => s } = task as any;
 
 	const spec = {
 		description: (ctx: Context<TState, TPath, TOp>) =>
@@ -282,8 +279,8 @@ function of<
 		condition: () => true,
 		...(typeof (task as any).effect === 'function'
 			? {
-					action: async (s: TState) => s,
-					effect: (s: TState) => s,
+					action: async (s: TState) => effect(s),
+					effect,
 			  }
 			: {}),
 		...task,

--- a/lib/testing/mermaid.spec.ts
+++ b/lib/testing/mermaid.spec.ts
@@ -348,42 +348,42 @@ describe('Mermaid', () => {
 				start -.- d0{ }
 				d0 -.- 822bf63[["+3"]]
 				822bf63 -.- edeeb11[["+2"]]
-				edeeb11 -.- c56cb39("+1")
-				c56cb39 -.- 863e4fe("+1")
-				863e4fe -.- 1dc6555("+1")
-				1dc6555 -.- d1{ }
+				edeeb11 -.- 8b74640("+1")
+				8b74640 -.- 927a1d9("+1")
+				927a1d9 -.- 93d33ca("+1")
+				93d33ca -.- d1{ }
 				d1 -.- 6edb6ff[["+3"]]
 				6edb6ff -.- 8f0ba02[["+2"]]
-				8f0ba02 -.- 3028816("+1")
-				3028816 -.- 113afc7("+1")
-				113afc7 -.- 29c4c3e("+1")
-				29c4c3e -.- d2{ }
+				8f0ba02 -.- 192c0db("+1")
+				192c0db -.- 823efa0("+1")
+				823efa0 -.- 2a4b707("+1")
+				2a4b707 -.- d2{ }
 				d2 -.- e3e8116[["+3"]]
 				e3e8116 -.- e3e8116-err[ ]
 				e3e8116-err:::error
 				d2 -.- 9649060[["+2"]]
 				9649060 -.- 9649060-err[ ]
 				9649060-err:::error
-				d2 -.- a7b0ba9("+1")
-				a7b0ba9 -.- stop(( ))
+				d2 -.- c9f44d7("+1")
+				c9f44d7 -.- stop(( ))
 				stop:::finish
 				classDef finish stroke:#000,fill:#000
 				start:::selected
-				start --> c56cb39
-				c56cb39:::selected
-				c56cb39 --> 863e4fe
-				863e4fe:::selected
-				863e4fe --> 1dc6555
-				1dc6555:::selected
-				1dc6555 --> 3028816
-				3028816:::selected
-				3028816 --> 113afc7
-				113afc7:::selected
-				113afc7 --> 29c4c3e
-				29c4c3e:::selected
-				29c4c3e --> a7b0ba9
-				a7b0ba9:::selected
-				a7b0ba9 --> stop
+				start --> 8b74640
+				8b74640:::selected
+				8b74640 --> 927a1d9
+				927a1d9:::selected
+				927a1d9 --> 93d33ca
+				93d33ca:::selected
+				93d33ca --> 192c0db
+				192c0db:::selected
+				192c0db --> 823efa0
+				823efa0:::selected
+				823efa0 --> 2a4b707
+				2a4b707:::selected
+				2a4b707 --> c9f44d7
+				c9f44d7:::selected
+				c9f44d7 --> stop
 				classDef error stroke:#f00
 				classDef selected stroke:#0f0
 			`,
@@ -424,53 +424,52 @@ describe('Mermaid', () => {
 				start(( ))
 				start -.- d0{ }
 				d0 -.- 588eea4[["increment counters"]]
-				588eea4 -.- 0874e9a("a + 1")
-				588eea4 -.- ef61a3a("b + 1")
-				0874e9a -.- jf4ad1f3
-				ef61a3a -.- jf4ad1f3
-				jf4ad1f3(( ))
-				jf4ad1f3 -.- d1{ }
+				588eea4 -.- 9071720("a + 1")
+				588eea4 -.- 7747bff("b + 1")
+				9071720 -.- j6b09f09
+				7747bff -.- j6b09f09
+				j6b09f09(( ))
+				j6b09f09 -.- d1{ }
 				d1 -.- c5108a8[["increment counters"]]
-				c5108a8 -.- 99bf28d("a + 1")
-				c5108a8 -.- bd9e0b4("b + 1")
-				99bf28d -.- j9ed3ea0
-				bd9e0b4 -.- j9ed3ea0
-				j9ed3ea0(( ))
-				j9ed3ea0 -.- d2{ }
+				c5108a8 -.- 6aa0594("a + 1")
+				c5108a8 -.- 2c5439a("b + 1")
+				6aa0594 -.- jf78e02c
+				2c5439a -.- jf78e02c
+				jf78e02c(( ))
+				jf78e02c -.- d2{ }
 				d2 -.- ee9e70b[["increment counters"]]
 				ee9e70b -.- ee9e70b-err[ ]
 				ee9e70b-err:::error
-				d2 -.- cea1c98("a + 1")
-				cea1c98 -.- stop(( ))
+				d2 -.- b75673e("a + 1")
+				b75673e -.- stop(( ))
 				stop:::finish
 				classDef finish stroke:#000,fill:#000
 				start:::selected
-				start --> fjf4ad1f3(( ))
-				fjf4ad1f3:::selected
-				fjf4ad1f3 --> 0874e9a
-				0874e9a:::selected
-				fjf4ad1f3 --> ef61a3a
-				ef61a3a:::selected
-				jf4ad1f3(( ))
-				0874e9a --> jf4ad1f3
-				ef61a3a --> jf4ad1f3
-				jf4ad1f3:::selected
-				jf4ad1f3 --> fj9ed3ea0(( ))
-				fj9ed3ea0:::selected
-				fj9ed3ea0 --> 99bf28d
-				99bf28d:::selected
-				fj9ed3ea0 --> bd9e0b4
-				bd9e0b4:::selected
-				j9ed3ea0(( ))
-				99bf28d --> j9ed3ea0
-				bd9e0b4 --> j9ed3ea0
-				j9ed3ea0:::selected
-				j9ed3ea0 --> cea1c98
-				cea1c98:::selected
-				cea1c98 --> stop
+				start --> fj6b09f09(( ))
+				fj6b09f09:::selected
+				fj6b09f09 --> 9071720
+				9071720:::selected
+				fj6b09f09 --> 7747bff
+				7747bff:::selected
+				j6b09f09(( ))
+				9071720 --> j6b09f09
+				7747bff --> j6b09f09
+				j6b09f09:::selected
+				j6b09f09 --> fjf78e02c(( ))
+				fjf78e02c:::selected
+				fjf78e02c --> 6aa0594
+				6aa0594:::selected
+				fjf78e02c --> 2c5439a
+				2c5439a:::selected
+				jf78e02c(( ))
+				6aa0594 --> jf78e02c
+				2c5439a --> jf78e02c
+				jf78e02c:::selected
+				jf78e02c --> b75673e
+				b75673e:::selected
+				b75673e --> stop
 				classDef error stroke:#f00
-				classDef selected stroke:#0f0
-			`,
+				classDef selected stroke:#0f0			`,
 		);
 	});
 
@@ -509,51 +508,50 @@ describe('Mermaid', () => {
 		planner.findPlan({ a: 0, b: 0 }, { a: 3, b: 2 });
 		expect(trace.render()).to.deep.equal(
 			dedent`
-			graph TD
-				start(( ))
-				start -.- d0{ }
-				d0 -.- 2396eea[["increment counters"]]
-				2396eea -.- 682aa0e[["increase 'a'"]]
-				682aa0e -.- f900ff9("a + 1")
-				f900ff9 -.- 00e5bb0("a + 1")
-				2396eea -.- 5dd218c[["increase 'b'"]]
-				5dd218c -.- 22ef581("b + 1")
-				22ef581 -.- d11a32a("b + 1")
-				00e5bb0 -.- j9ed3ea0
-				d11a32a -.- j9ed3ea0
-				j9ed3ea0(( ))
-				j9ed3ea0 -.- d1{ }
-				d1 -.- 7de2726[["increment counters"]]
-				7de2726 -.- 7de2726-err[ ]
-				7de2726-err:::error
-				d1 -.- 976345d[["increase 'a'"]]
-				976345d -.- 976345d-err[ ]
-				976345d-err:::error
-				d1 -.- 2f364fb("a + 1")
-				2f364fb -.- stop(( ))
-				stop:::finish
-				classDef finish stroke:#000,fill:#000
-				start:::selected
-				start --> fjf4ad1f3(( ))
-				fjf4ad1f3:::selected
-				fjf4ad1f3 --> f900ff9
-				f900ff9:::selected
-				f900ff9 --> 00e5bb0
-				00e5bb0:::selected
-				fjf4ad1f3 --> 22ef581
-				22ef581:::selected
-				22ef581 --> d11a32a
-				d11a32a:::selected
-				jf4ad1f3(( ))
-				00e5bb0 --> jf4ad1f3
-				d11a32a --> jf4ad1f3
-				jf4ad1f3:::selected
-				jf4ad1f3 --> 2f364fb
-				2f364fb:::selected
-				2f364fb --> stop
-				classDef error stroke:#f00
-				classDef selected stroke:#0f0
-			`,
+				graph TD
+					start(( ))
+					start -.- d0{ }
+					d0 -.- 2396eea[["increment counters"]]
+					2396eea -.- 682aa0e[["increase 'a'"]]
+					682aa0e -.- f564b6b("a + 1")
+					f564b6b -.- 0d3673e("a + 1")
+					2396eea -.- 5dd218c[["increase 'b'"]]
+					5dd218c -.- d4ee1fa("b + 1")
+					d4ee1fa -.- c7319a4("b + 1")
+					0d3673e -.- jf78e02c
+					c7319a4 -.- jf78e02c
+					jf78e02c(( ))
+					jf78e02c -.- d1{ }
+					d1 -.- 7de2726[["increment counters"]]
+					7de2726 -.- 7de2726-err[ ]
+					7de2726-err:::error
+					d1 -.- 976345d[["increase 'a'"]]
+					976345d -.- 976345d-err[ ]
+					976345d-err:::error
+					d1 -.- 468e422("a + 1")
+					468e422 -.- stop(( ))
+					stop:::finish
+					classDef finish stroke:#000,fill:#000
+					start:::selected
+					start --> fj6b09f09(( ))
+					fj6b09f09:::selected
+					fj6b09f09 --> f564b6b
+					f564b6b:::selected
+					f564b6b --> 0d3673e
+					0d3673e:::selected
+					fj6b09f09 --> d4ee1fa
+					d4ee1fa:::selected
+					d4ee1fa --> c7319a4
+					c7319a4:::selected
+					j6b09f09(( ))
+					0d3673e --> j6b09f09
+					c7319a4 --> j6b09f09
+					j6b09f09:::selected
+					j6b09f09 --> 468e422
+					468e422:::selected
+					468e422 --> stop
+					classDef error stroke:#f00
+					classDef selected stroke:#0f0			`,
 		);
 	});
 
@@ -622,86 +620,85 @@ describe('Mermaid', () => {
 		planner.findPlan({ a: 0, b: 0, c: 0, d: 0 }, { a: 3, b: 2, c: 2, d: 2 });
 		expect(trace.render()).to.deep.equal(
 			dedent`
-			graph TD
-				start(( ))
-				start -.- d0{ }
-				d0 -.- 16c4cee[["chunk"]]
-				16c4cee -.- 85de134[["increment multiple"]]
-				85de134 -.- f086833[["a + 2"]]
-				f086833 -.- b97653c("a++")
-				b97653c -.- fdd46f5("a++")
-				85de134 -.- 491551c[["b + 2"]]
-				491551c -.- 76d9b13("b++")
-				76d9b13 -.- 0d8a6c4("b++")
-				16c4cee -.- 14b5abe[["increment multiple"]]
-				14b5abe -.- a6594ae[["c + 2"]]
-				a6594ae -.- fb528c3("c++")
-				fb528c3 -.- d7c9a30("c++")
-				14b5abe -.- 9a04ffd[["d + 2"]]
-				9a04ffd -.- b0c761f("d++")
-				b0c761f -.- d970700("d++")
-				fdd46f5 -.- jef318f8
-				0d8a6c4 -.- jef318f8
-				jef318f8(( )) -.- 25e807e
-				d7c9a30 -.- j902d46d
-				d970700 -.- j902d46d
-				j902d46d(( )) -.- 25e807e
-				25e807e(( ))
-				25e807e -.- d1{ }
-				d1 -.- cb79260[["chunk"]]
-				cb79260 -.- cb79260-err[ ]
-				cb79260-err:::error
-				d1 -.- a65b91b[["increment multiple"]]
-				a65b91b -.- a65b91b-err[ ]
-				a65b91b-err:::error
-				d1 -.- 8923404[["a + 2"]]
-				8923404 -.- 8923404-err[ ]
-				8923404-err:::error
-				d1 -.- 7a51307("a++")
-				7a51307 -.- stop(( ))
-				stop:::finish
-				classDef finish stroke:#000,fill:#000
-				start:::selected
-				start --> f3a3585e(( ))
-				f3a3585e:::selected
-				f3a3585e --> fjb462b59(( ))
-				fjb462b59:::selected
-				fjb462b59 --> b97653c
-				b97653c:::selected
-				b97653c --> fdd46f5
-				fdd46f5:::selected
-				fjb462b59 --> 76d9b13
-				76d9b13:::selected
-				76d9b13 --> 0d8a6c4
-				0d8a6c4:::selected
-				jb462b59(( ))
-				fdd46f5 --> jb462b59
-				0d8a6c4 --> jb462b59
-				jb462b59:::selected
-				f3a3585e --> fj47a9bc7(( ))
-				fj47a9bc7:::selected
-				fj47a9bc7 --> fb528c3
-				fb528c3:::selected
-				fb528c3 --> d7c9a30
-				d7c9a30:::selected
-				fj47a9bc7 --> b0c761f
-				b0c761f:::selected
-				b0c761f --> d970700
-				d970700:::selected
-				j47a9bc7(( ))
-				d7c9a30 --> j47a9bc7
-				d970700 --> j47a9bc7
-				j47a9bc7:::selected
-				3a3585e(( ))
-				jb462b59 --> 3a3585e
-				j47a9bc7 --> 3a3585e
-				3a3585e:::selected
-				3a3585e --> 7a51307
-				7a51307:::selected
-				7a51307 --> stop
-				classDef error stroke:#f00
-				classDef selected stroke:#0f0
-			`,
+				graph TD
+					start(( ))
+					start -.- d0{ }
+					d0 -.- 16c4cee[["chunk"]]
+					16c4cee -.- 85de134[["increment multiple"]]
+					85de134 -.- f086833[["a + 2"]]
+					f086833 -.- 6725504("a++")
+					6725504 -.- d9eff37("a++")
+					85de134 -.- 491551c[["b + 2"]]
+					491551c -.- bb6a327("b++")
+					bb6a327 -.- 1b3d60d("b++")
+					16c4cee -.- 14b5abe[["increment multiple"]]
+					14b5abe -.- a6594ae[["c + 2"]]
+					a6594ae -.- 79ef4af("c++")
+					79ef4af -.- d7098f4("c++")
+					14b5abe -.- 9a04ffd[["d + 2"]]
+					9a04ffd -.- 62f8002("d++")
+					62f8002 -.- 5e7f342("d++")
+					d9eff37 -.- jfb9402c
+					1b3d60d -.- jfb9402c
+					jfb9402c(( )) -.- 9034b1e
+					d7098f4 -.- jb231a35
+					5e7f342 -.- jb231a35
+					jb231a35(( )) -.- 9034b1e
+					9034b1e(( ))
+					9034b1e -.- d1{ }
+					d1 -.- cb79260[["chunk"]]
+					cb79260 -.- cb79260-err[ ]
+					cb79260-err:::error
+					d1 -.- a65b91b[["increment multiple"]]
+					a65b91b -.- a65b91b-err[ ]
+					a65b91b-err:::error
+					d1 -.- 8923404[["a + 2"]]
+					8923404 -.- 8923404-err[ ]
+					8923404-err:::error
+					d1 -.- e51d42f("a++")
+					e51d42f -.- stop(( ))
+					stop:::finish
+					classDef finish stroke:#000,fill:#000
+					start:::selected
+					start --> f56cffb0(( ))
+					f56cffb0:::selected
+					f56cffb0 --> fj18095dd(( ))
+					fj18095dd:::selected
+					fj18095dd --> 6725504
+					6725504:::selected
+					6725504 --> d9eff37
+					d9eff37:::selected
+					fj18095dd --> bb6a327
+					bb6a327:::selected
+					bb6a327 --> 1b3d60d
+					1b3d60d:::selected
+					j18095dd(( ))
+					d9eff37 --> j18095dd
+					1b3d60d --> j18095dd
+					j18095dd:::selected
+					f56cffb0 --> fj343bab8(( ))
+					fj343bab8:::selected
+					fj343bab8 --> 79ef4af
+					79ef4af:::selected
+					79ef4af --> d7098f4
+					d7098f4:::selected
+					fj343bab8 --> 62f8002
+					62f8002:::selected
+					62f8002 --> 5e7f342
+					5e7f342:::selected
+					j343bab8(( ))
+					d7098f4 --> j343bab8
+					5e7f342 --> j343bab8
+					j343bab8:::selected
+					56cffb0(( ))
+					j18095dd --> 56cffb0
+					j343bab8 --> 56cffb0
+					56cffb0:::selected
+					56cffb0 --> e51d42f
+					e51d42f:::selected
+					e51d42f --> stop
+					classDef error stroke:#f00
+					classDef selected stroke:#0f0			`,
 		);
 	});
 
@@ -740,36 +737,36 @@ describe('Mermaid', () => {
 		planner.findPlan({ a: 0, b: 0 }, { a: 3, b: 2 });
 		expect(trace.render()).to.deep.equal(
 			dedent`
-			graph TD
-				start(( ))
-				start -.- d0{ }
-				d0 -.- 817288c[["increment counters"]]
-				817288c -.- 570ec53("a + 1")
-				570ec53 -.- 00e5bb0("a + 1")
-				00e5bb0 -.- 78cc211("b + 1")
-				78cc211 -.- d11a32a("b + 1")
-				d11a32a -.- d1{ }
-				d1 -.- 4b2ca33[["increment counters"]]
-				4b2ca33 -.- 4b2ca33-err[ ]
-				4b2ca33-err:::error
-				d1 -.- 2f364fb("a + 1")
-				2f364fb -.- stop(( ))
-				stop:::finish
-				classDef finish stroke:#000,fill:#000
-				start:::selected
-				start --> 570ec53
-				570ec53:::selected
-				570ec53 --> 00e5bb0
-				00e5bb0:::selected
-				00e5bb0 --> 78cc211
-				78cc211:::selected
-				78cc211 --> d11a32a
-				d11a32a:::selected
-				d11a32a --> 2f364fb
-				2f364fb:::selected
-				2f364fb --> stop
-				classDef error stroke:#f00
-				classDef selected stroke:#0f0
+				graph TD
+					start(( ))
+					start -.- d0{ }
+					d0 -.- 817288c[["increment counters"]]
+					817288c -.- ac5943a("a + 1")
+					ac5943a -.- 0d3673e("a + 1")
+					0d3673e -.- 002f81e("b + 1")
+					002f81e -.- c7319a4("b + 1")
+					c7319a4 -.- d1{ }
+					d1 -.- 4b2ca33[["increment counters"]]
+					4b2ca33 -.- 4b2ca33-err[ ]
+					4b2ca33-err:::error
+					d1 -.- 468e422("a + 1")
+					468e422 -.- stop(( ))
+					stop:::finish
+					classDef finish stroke:#000,fill:#000
+					start:::selected
+					start --> ac5943a
+					ac5943a:::selected
+					ac5943a --> 0d3673e
+					0d3673e:::selected
+					0d3673e --> 002f81e
+					002f81e:::selected
+					002f81e --> c7319a4
+					c7319a4:::selected
+					c7319a4 --> 468e422
+					468e422:::selected
+					468e422 --> stop
+					classDef error stroke:#f00
+					classDef selected stroke:#0f0
 			`,
 		);
 	});


### PR DESCRIPTION
Actions until now would default to throwing a `NotImplemented` exception, however it may be generally useful to have tasks without side effects combined with tasks that perform side effects for more clean code. For this reason, if undefined, the `action` property will take the value of the `effect` property from now on.

Change-type: minor