### PR TITLE
Fix bug when mapping effects

### DIFF
--- a/lib/task/effect.spec.ts
+++ b/lib/task/effect.spec.ts
@@ -28,6 +28,39 @@ describe('Effect', () => {
 		expect(await effect).to.equal(4);
 	});
 
+	it('allows void effects', async () => {
+		const effect = (x: number) =>
+			Effect.of(void 0)
+				.map(() => {
+					x += 1;
+				})
+				.flatMap(() =>
+					Effect.from(
+						async () => {
+							console.log('yes');
+							x += 2;
+						},
+						() => {
+							console.log('no');
+							x += 1;
+						},
+					),
+				)
+				.flatMap(() =>
+					Effect.from(
+						async () => {
+							x += 1;
+						},
+						() => {
+							x += 1;
+						},
+					),
+				)
+				.map(() => x);
+		// expect(effect(0)()).to.equal(3);
+		expect(await effect(0)).to.equal(4);
+	});
+
 	it('propagates errors in a promise', async () => {
 		const effect = Effect.of(0)
 			.map((x) => x + 1)

--- a/lib/task/effect.ts
+++ b/lib/task/effect.ts
@@ -113,7 +113,10 @@ function build<T>(
 			);
 		},
 		flatMap<U>(fu: (t: T) => Effect<U>): Effect<U> {
-			return build<U>(() => obs().flatMap((t) => fu(t)), fu(sync()));
+			return build<U>(
+				() => obs().flatMap((t) => fu(t)),
+				() => fu(sync())(),
+			);
 		},
 	});
 }


### PR DESCRIPTION
Mapping effects would lead to the synchronous side to always be executed. This is most noticeable when mapping `void` effects

Change-type: patch