### PR TITLE
Add Target constructor

### DIFF
--- a/lib/target.spec.ts
+++ b/lib/target.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from '~/test-utils';
+import { Target, UNDEFINED } from './target';
+
+describe('Target', () => {
+	describe('from', () => {
+		it('adds UNDEFINED symbols for missing values on the target', () => {
+			type S = {
+				a: number;
+				b?: string;
+				c: { d?: { e: number; f?: string } };
+				g: { [k: string]: string };
+			};
+			const state: S = {
+				a: 1,
+				b: 'foo',
+				c: { d: { e: 2, f: 'bar' } },
+				g: { i: 'goodbye' },
+			};
+
+			expect(
+				Target.from(state, {
+					a: 1,
+					c: { d: { e: 3, f: undefined } },
+					g: { h: 'hello' },
+				}),
+			).to.deep.equal({
+				a: 1,
+				b: UNDEFINED,
+				c: {
+					d: { e: 3, f: UNDEFINED },
+				},
+				g: { h: 'hello', i: UNDEFINED },
+			});
+		});
+	});
+});

--- a/lib/target.ts
+++ b/lib/target.ts
@@ -15,3 +15,43 @@ export type Target<S> = S extends any[] | ((...args: any) => any)
 				: Target<S[P]>;
 	  }
 	: S;
+
+type WithOptional<S> = S extends any[] | ((...args: any) => any)
+	? S
+	: S extends object
+	? {
+			[P in keyof S]: IsOptional<S, P> extends true
+				? // Only optional properties can be undefined
+				  WithOptional<S[P]> | undefined
+				: WithOptional<S[P]>;
+	  }
+	: S;
+
+/**
+ * Create a new target from the current state and
+ * a partial state. This is useful to have a cleaner interface
+ * that just provides the values that need to be changed.
+ */
+function from<S>(state: S, target: WithOptional<S>): Target<S> {
+	const queue: Array<{ s: any; t: any }> = [{ s: state, t: target }];
+
+	while (queue.length > 0) {
+		const { s, t } = queue.shift()!;
+
+		for (const key of Object.keys(s)) {
+			if (!(key in t) || (t[key] === undefined && s[key] !== undefined)) {
+				// UNDEFINED means delete the value
+				t[key] = UNDEFINED;
+			} else if (typeof t[key] === 'object') {
+				// If the value is an object, we need to recurse
+				queue.push({ s: s[key], t: t[key] });
+			}
+		}
+	}
+
+	return target;
+}
+
+export const Target = {
+	from,
+};


### PR DESCRIPTION
Allows to get a Target object by comparing a desired state with the current state and adding `UNDEFINED` symbols for deleted values.

Change-type: minor