### PR TITLE
Make Agent maxRetries count failed plan runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A automated task composer and [HTN](https://en.wikipedia.org/wiki/Hierarchical_task_network) based planner for building autonomous system agents in typescript.
 
-**NOTE** even though this project is on its v1, we still consider it experimental, as we continue exploring different mechanisms to improve efficiency of various aspects of the framework. This project does adhere to the [semantic versioning guidelines](https://semver.org/), so we wont perform any breaking API changes without a major version bump.
+**NOTE** even though this project is out of v0.x, we still consider it experimental, as we continue exploring different mechanisms to improve efficiency of various aspects of the framework. This project does adhere to the [semantic versioning guidelines](https://semver.org/), so we wont perform any breaking API changes without a major version bump.
 
 ## Features
 
@@ -1480,7 +1480,7 @@ const WifiConnect = Agent.from<State>({
 		// We want the agent to run forever
 		follow: true,
 		// And keep retrying on failure (this is the default)
-		maxRetries: 0,
+		maxRetries: Infinity,
 	},
 });
 ```

--- a/lib/agent/index.ts
+++ b/lib/agent/index.ts
@@ -184,7 +184,7 @@ function from<TState>({
 	opts?: DeepPartial<AgentOpts>;
 }): Agent<TState> {
 	const opts: AgentOpts = {
-		maxRetries: 0,
+		maxRetries: Infinity,
 		follow: false,
 		maxWaitMs: 5 * 60 * 1000,
 		minWaitMs: 1 * 1000,

--- a/lib/agent/types.ts
+++ b/lib/agent/types.ts
@@ -11,7 +11,7 @@ export interface AgentOpts {
 	follow: boolean;
 
 	/**
-	 * The maximum number of attempts for finding a plan before giving up. Defaults to
+	 * The maximum number of attempts for reaching the target before giving up. Defaults to
 	 * infinite tries.
 	 */
 	maxRetries: number;
@@ -64,7 +64,7 @@ export class Stopped extends Error {
  */
 export class Failure extends Error {
 	constructor(tries: number) {
-		super('Agent failed to find a plan after ' + tries + ' attempts');
+		super('Agent failed to reach target after ' + tries + ' attempts');
 	}
 }
 


### PR DESCRIPTION
Before only failures to find a plan would count against the maxRetries Agent options, which is really an error in design as that would not leave to abort a failing plan.

This also changes maxRetries to default to Infinity, leaving maxRetries: 0 to mean that the agent will exit after a single try.

While this fixes some bad design decisions, this is a breaking change.

Change-type: major