### PR TITLE
Allow ignoring certain paths in Target construtor

### DIFF
--- a/lib/target.spec.ts
+++ b/lib/target.spec.ts
@@ -32,5 +32,39 @@ describe('Target', () => {
 				g: { h: 'hello', i: UNDEFINED },
 			});
 		});
+
+		it('ignores paths matching globs on the list', () => {
+			type S = {
+				a: number;
+				b?: string;
+				c: { d?: { e: number; f?: string }; h?: string };
+				g: { [k: string]: string };
+			};
+			const state: S = {
+				a: 1,
+				b: 'foo',
+				c: { d: { e: 2, f: 'bar' }, h: 'baz' },
+				g: { i: 'goodbye' },
+			};
+
+			expect(
+				Target.from(
+					state,
+					{
+						a: 1,
+						c: { d: { e: 3, f: undefined } },
+						g: { h: 'hello' },
+					},
+					['/b', '*/g', '/c/*/f'],
+				),
+			).to.deep.equal({
+				a: 1,
+				c: {
+					d: { e: 3, f: UNDEFINED },
+					h: UNDEFINED,
+				},
+				g: { h: 'hello' },
+			});
+		});
 	});
 });

--- a/lib/target.ts
+++ b/lib/target.ts
@@ -27,24 +27,45 @@ type WithOptional<S> = S extends any[] | ((...args: any) => any)
 	    }
 	  : S;
 
+function globToRegExp(glob: string): RegExp {
+	const parts = glob.split('*');
+	const regex = parts.map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+	return new RegExp(`^${regex.join('[^/]*')}$`);
+}
+
 /**
  * Create a new target from the current state and
  * a partial state. This is useful to have a cleaner interface
  * that just provides the values that need to be changed.
+ *
+ * The process will skip any target paths matching the given globs. Note that glob
+ * support is very limited, and only supports `*` as special characters.
  */
-function from<S>(state: S, target: WithOptional<S>): Target<S> {
-	const queue: Array<{ s: any; t: any }> = [{ s: state, t: target }];
+function from<S>(
+	state: S,
+	target: WithOptional<S>,
+	ignoreGlobs = [] as string[],
+): Target<S> {
+	const queue: Array<{ s: any; t: any; p: string }> = [
+		{ s: state, t: target, p: '' },
+	];
+
+	const ignore = ignoreGlobs.map(globToRegExp);
 
 	while (queue.length > 0) {
-		const { s, t } = queue.shift()!;
+		const { s, t, p } = queue.shift()!;
 
 		for (const key of Object.keys(s)) {
-			if (!(key in t) || (t[key] === undefined && s[key] !== undefined)) {
+			if (key in t && t[key] === undefined && s[key] !== undefined) {
+				t[key] = UNDEFINED;
+			} else if (ignore.some((r) => r.test(`${p}/${key}`))) {
+				continue;
+			} else if (!(key in t)) {
 				// UNDEFINED means delete the value
 				t[key] = UNDEFINED;
 			} else if (typeof t[key] === 'object') {
 				// If the value is an object, we need to recurse
-				queue.push({ s: s[key], t: t[key] });
+				queue.push({ s: s[key], t: t[key], p: `${p}/${key}` });
 			}
 		}
 	}


### PR DESCRIPTION
Allows users construct a target that ignores some removals from the source object.

Change-type: minor