### PR TITLE
Return a copy of the state from agent runtime

### DIFF
--- a/lib/agent/runtime.ts
+++ b/lib/agent/runtime.ts
@@ -232,7 +232,10 @@ export class Runtime<TState> {
 					// The plan is empty, we have reached the goal
 					if (start == null) {
 						logger.info('nothing else to do: target state reached');
-						return { success: true as const, state: this.stateRef._ };
+						return {
+							success: true as const,
+							state: structuredClone(this.stateRef._),
+						};
 					}
 
 					const plan: string[] = [];


### PR DESCRIPTION
The promise was returning a reference to the state, meaning future runs of the agent could change the object returned in a past run. Using structuredClone avoids this issue

Change-type: patch