### PR TITLE
Use lens template to parse paths

### DIFF
--- a/lib/lens.spec.ts
+++ b/lib/lens.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '~/test-utils';
-import { Lens } from './lens';
+import { Lens, Template } from './lens';
 
 describe('Lens', () => {
 	describe('context', () => {
@@ -65,6 +65,18 @@ describe('Lens', () => {
 				target: 'one',
 				pos: 0,
 			});
+		});
+	});
+
+	describe('Template', () => {
+		it('allows to split a path using the template definition', () => {
+			const template = Template.from('/a/:b/c');
+			expect(template.split('/a/one/c')).to.deep.equal(['a', 'one', 'c']);
+			expect(template.split('/a/one/two/three/c')).to.deep.equal([
+				'a',
+				'one/two/three',
+				'c',
+			]);
 		});
 	});
 });

--- a/lib/task/tasks.ts
+++ b/lib/task/tasks.ts
@@ -289,9 +289,15 @@ function ground<
 	if (isActionSpec(task)) {
 		const { effect: taskEffect, action: taskAction } = task;
 		const effect = (s: Ref<TState>) =>
-			taskEffect(View.from(s, path as TPath), { ...context, system: s._ });
+			taskEffect(View.from(s, path as TPath, task.lens), {
+				...context,
+				system: s._,
+			});
 		const action = async (s: Ref<TState>) =>
-			taskAction(View.from(s, path as TPath), { ...context, system: s._ });
+			taskAction(View.from(s, path as TPath, task.lens), {
+				...context,
+				system: s._,
+			});
 		return Object.assign(action, {
 			id,
 			path: context.path as TPath,

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -2,7 +2,7 @@ import { isArrayIndex } from './is-array-index';
 import { Path } from './path';
 import { InvalidPointer } from './pointer';
 import { Ref } from './ref';
-import { Lens } from './lens';
+import { Lens, Template } from './lens';
 
 export interface View<TState, TPath extends Path = '/'>
 	extends Ref<Lens<TState, TPath>> {
@@ -14,10 +14,11 @@ export interface View<TState, TPath extends Path = '/'>
  */
 function createView<TState, TPath extends Path>(
 	ref: Ref<TState>,
-	path: TPath,
+	path: Path,
+	lens = path as TPath,
 ): View<TState, TPath> {
-	Path.assert(path);
-	const parts = Path.elems(path);
+	const template = Template.from(lens);
+	const parts = template.split(path);
 
 	// Save the last element of the path so we can delete it
 	const last = parts.pop();


### PR DESCRIPTION
Paths were being parsed splitting by '/' which prevents users using a URI (for instance) as an object key in the state object. With this change, the library will now use the lens template to match against the given path to correctly reference state properties

Change-type: patch