### PR TITLE
Convert Path type into a branded type

### DIFF
--- a/lib/distance.ts
+++ b/lib/distance.ts
@@ -16,7 +16,7 @@ export interface Distance<S> {
 	 * If the array is empty, that means the object meets the target and no more
 	 * changes are necessary.
 	 */
-	(s: S): Array<Operation<S, any>>;
+	(s: S): Array<Operation<S, Path>>;
 
 	/**
 	 * Get the target of this diff. Note that because of how targets are defined,
@@ -54,11 +54,11 @@ type TreeOperation<S, P extends Path> = Operation<S, P> & { isLeaf: boolean };
 function* getOperations<S>(
 	s: S,
 	t: Target<S>,
-): Iterable<TreeOperation<S, any>> {
+): Iterable<TreeOperation<S, Path>> {
 	// We store target, path pair in a quee so we can visit the full target
 	// object, ordered by level, without recursion
-	const queue: Array<{ tgt: Target<any>; path: Path; isLeaf?: false }> = [
-		{ tgt: t, path: '' },
+	const queue: Array<{ tgt: Target<any>; ref: string[]; isLeaf?: false }> = [
+		{ tgt: t, ref: [] },
 	];
 
 	// The target object
@@ -66,8 +66,9 @@ function* getOperations<S>(
 
 	// The list of operations to return
 	while (queue.length > 0) {
-		const { tgt, path, isLeaf } = queue.shift()!;
+		const { tgt, ref, isLeaf } = queue.shift()!;
 
+		const path = Path.from(ref);
 		const sValue = Pointer.from(s, path);
 		const tValue = Pointer.from(patched, path);
 
@@ -86,7 +87,7 @@ function* getOperations<S>(
 			else if (!equals(sValue, tValue)) {
 				yield {
 					op: 'update',
-					path: path === '' ? '/' : path,
+					path,
 					source: sValue!,
 					target: tValue!,
 					isLeaf:
@@ -110,8 +111,8 @@ function* getOperations<S>(
 			// Add target keys to stack to recurse
 			for (const key of Object.keys(tgt)) {
 				const value = tgt[key];
-				const newPath = `${path}/${key}`;
-				queue.push({ tgt: value, path: newPath });
+				const newPath = ref.concat(key);
+				queue.push({ tgt: value, ref: newPath });
 			}
 		}
 
@@ -124,10 +125,10 @@ function* getOperations<S>(
 			typeof sValue === 'object'
 		) {
 			for (const key of Object.keys(sValue)) {
-				const newPath = `${path}/${key}`;
+				const newPath = ref.concat(key);
 				// We set isLeaf to false here because we know that the source
 				// comes from a previous iteration
-				queue.push({ tgt: UNDEFINED, path: newPath, isLeaf: false });
+				queue.push({ tgt: UNDEFINED, ref: newPath, isLeaf: false });
 			}
 		}
 	}

--- a/lib/lens.spec.ts
+++ b/lib/lens.spec.ts
@@ -1,11 +1,15 @@
 import { expect } from '~/test-utils';
 import { Lens } from './lens';
+import { Path } from './path';
 
 describe('Lens', () => {
 	describe('context', () => {
 		it('gets context from generic dictionary', () => {
 			type Counters = { [K in keyof any]: number };
-			const c = Lens.context<Counters, '/'>(`/`, `/`, { a: 1, b: 2 });
+			const c = Lens.context<Counters, '/'>(Path.from(`/`), Path.from(`/`), {
+				a: 1,
+				b: 2,
+			});
 			expect(c).to.deep.include({
 				target: { a: 1, b: 2 },
 			});
@@ -14,10 +18,11 @@ describe('Lens', () => {
 		it('calculates a simple context', () => {
 			type State = { a: { b: { c: string[] }; d: number } };
 
-			const c = Lens.context<State, '/a/b/:value'>('/a/b/:value', '/a/b/c', [
-				'one',
-				'two',
-			]);
+			const c = Lens.context<State, '/a/b/:value'>(
+				Path.from('/a/b/:value'),
+				Path.from('/a/b/c'),
+				['one', 'two'],
+			);
 
 			expect(c).to.deep.include({
 				target: ['one', 'two'],
@@ -29,8 +34,8 @@ describe('Lens', () => {
 			type State = { objects: { [id: string]: { value: number } } };
 
 			const ctx = Lens.context<State, '/objects/:id'>(
-				'/objects/:id',
-				'/objects/second',
+				Path.from('/objects/:id'),
+				Path.from('/objects/second'),
 				{ value: 123 },
 			);
 
@@ -41,8 +46,8 @@ describe('Lens', () => {
 			type State = { a: { b: { c: string[] }; d: number } };
 
 			const c = Lens.context<State, '/a/b/c/:pos'>(
-				'/a/b/c/:pos',
-				'/a/b/c/0',
+				Path.from('/a/b/c/:pos'),
+				Path.from('/a/b/c/0'),
 				'one',
 			);
 
@@ -56,8 +61,8 @@ describe('Lens', () => {
 			type State = { a: { b: { c: Array<{ e: string }> }; d: number } };
 
 			const c = Lens.context<State, '/a/b/c/:pos/e'>(
-				'/a/b/c/:pos/e',
-				'/a/b/c/0/e',
+				Path.from('/a/b/c/:pos/e'),
+				Path.from('/a/b/c/0/e'),
 				'one',
 			);
 

--- a/lib/lens.ts
+++ b/lib/lens.ts
@@ -22,7 +22,10 @@ type LensWithSlash<
 	TProps extends NonNullable<unknown>,
 > = TPath extends `/${infer TTail}`
 	? LensWithoutSlash<TChildState, TPath, TTail, TProps> // If the path starts with a slash, evaluate the remaining part of the path
-	: never; // Otherwise, the path is invalid
+	: TProps & {
+			path: Path<TPath>;
+			target: unknown;
+	  }; // Otherwise, the path is invalid
 
 // A lens to evaluate paths that start without a slash, e.g. `key1/key2` or `key`
 type LensWithoutSlash<

--- a/lib/operation.ts
+++ b/lib/operation.ts
@@ -1,23 +1,23 @@
-import { Path } from './path';
+import { Path, PathString, Root } from './path';
 import { Pointer } from './pointer';
 
-interface CreateOperation<T, P extends Path> {
+interface CreateOperation<T, P extends PathString> {
 	op: 'create';
-	path: P;
+	path: Path<P>;
 	target: Pointer<T, P>;
 }
-interface DeleteOperation<P extends Path> {
+interface DeleteOperation<P extends PathString> {
 	op: 'delete';
-	path: P;
+	path: Path<P>;
 }
-interface UpdateOperation<T, P extends Path> {
+interface UpdateOperation<T, P extends PathString> {
 	op: 'update';
-	path: P;
+	path: Path<P>;
 	source: Pointer<T, P>;
 	target: Pointer<T, P>;
 }
 
-export type Operation<T = any, P extends Path = '/'> =
+export type Operation<T = any, P extends PathString = Root> =
 	| CreateOperation<T, P>
 	| DeleteOperation<P>
 	| UpdateOperation<T, P>;

--- a/lib/path.spec.ts
+++ b/lib/path.spec.ts
@@ -2,19 +2,23 @@ import { expect } from '~/test-utils';
 import { Path } from './path';
 
 describe('Path', () => {
-	describe('is', () => {
+	describe('from', () => {
 		it('validates a path', () => {
-			expect(Path.is('')).to.be.true;
-			expect(Path.is('/')).to.be.true;
-			expect(Path.is('/a/b/c')).to.be.true;
-			expect(Path.is('/a/b1')).to.be.true;
-			expect(Path.is('/a/b/1')).to.be.true;
-			expect(Path.is('/a/:value/1')).to.be.true;
-			expect(Path.is('/a/b_c-123#/1')).to.be.true;
-			expect(Path.is('a/b/1')).to.be.false;
-			expect(Path.is('a/b//1')).to.be.false;
-			expect(Path.is('a/b/ /1')).to.be.false;
-			expect(Path.is('a/b/😛/1')).to.be.false;
+			expect(() => Path.from('a/b/1')).to.throw;
+			expect(() => Path.from('a/b//1')).to.throw;
+			expect(() => Path.from('a/b/ /1')).to.throw;
+			expect(() => Path.from('a/b/😛/1')).to.throw;
+		});
+
+		it('creates a path from either as string or a string array', () => {
+			expect(Path.from([])).to.equal('/');
+			expect(Path.from('')).to.equal('');
+			expect(Path.from('/')).to.equal('/');
+			expect(Path.from(['a', 'b', 'c'])).to.equal('/a/b/c');
+			expect(Path.from('/a/b/c')).to.equal('/a/b/c');
+			expect(Path.from('/a/b1')).to.equal('/a/b1');
+			expect(Path.from('/a/b/1')).to.equal('/a/b/1');
+			expect(Path.from('/a/b_c-123#/1')).to.equal('/a/b_c-123#/1');
 		});
 	});
 });

--- a/lib/planner/findPlan.ts
+++ b/lib/planner/findPlan.ts
@@ -26,7 +26,7 @@ import { isTaskApplicable } from './utils';
 
 interface PlanningState<TState = any> {
 	distance: Distance<TState>;
-	tasks: Array<Task<TState>>;
+	tasks: Array<Task<TState, string, any>>;
 	depth?: number;
 	operation?: Operation<TState, any>;
 	trace: PlannerConfig<TState>['trace'];
@@ -416,13 +416,13 @@ export function findPlan<TState = any>({
 			// we get the target value for the context from the pointer
 			// if the operation is delete, the pointer will be undefined
 			// which is the right value for that operation
-			const ctx = Lens.context<TState, any>(
+			const ctx = Lens.context<TState, string>(
 				task.lens,
 				path,
-				Pointer.from<TState, string>(distance.target, path) as any,
+				Pointer.from<TState, string>(distance.target, path),
 			);
 
-			const taskPlan = tryInstruction(task(ctx as any), {
+			const taskPlan = tryInstruction(task(ctx), {
 				depth,
 				distance: distance,
 				tasks,

--- a/lib/planner/findPlan.ts
+++ b/lib/planner/findPlan.ts
@@ -1,29 +1,28 @@
 import {
-	diff as createPatch,
-	patch as applyPatch,
 	Operation as PatchOperation,
+	patch as applyPatch,
+	diff as createPatch,
 } from 'mahler-wasm';
 
-import { Lens } from '../lens';
+import assert from '../assert';
 import { Distance } from '../distance';
+import { Lens } from '../lens';
 import { Operation } from '../operation';
-import { Path } from '../path';
 import { Pointer } from '../pointer';
 import { Ref } from '../ref';
-import { Action, Instruction, Method, Task, MethodExpansion } from '../task';
-import { Plan } from './plan';
+import { Action, Instruction, Method, MethodExpansion, Task } from '../task';
 import { EmptyNode, Node } from './node';
+import { Plan } from './plan';
 import {
-	PlannerConfig,
-	LoopDetected,
-	RecursionDetected,
-	MethodExpansionEmpty,
 	ConditionNotMet,
-	SearchFailed,
+	LoopDetected,
 	MergeFailed,
+	MethodExpansionEmpty,
+	PlannerConfig,
+	RecursionDetected,
+	SearchFailed,
 } from './types';
 import { isTaskApplicable } from './utils';
-import assert from '../assert';
 
 interface PlanningState<TState = any> {
 	distance: Distance<TState>;
@@ -411,7 +410,7 @@ export function findPlan<TState = any>({
 
 			// Extract the path from the task template and the
 			// operation
-			const path: Path = operation.path;
+			const path = operation.path;
 
 			// Get the context expected by the task
 			// we get the target value for the context from the pointer
@@ -420,7 +419,7 @@ export function findPlan<TState = any>({
 			const ctx = Lens.context<TState, any>(
 				task.lens,
 				path,
-				Pointer.from(distance.target, path)!,
+				Pointer.from<TState, string>(distance.target, path) as any,
 			);
 
 			const taskPlan = tryInstruction(task(ctx as any), {

--- a/lib/planner/utils.ts
+++ b/lib/planner/utils.ts
@@ -1,5 +1,5 @@
 import { Task, TaskOp } from '../task';
-import { Path } from '../path';
+import { Path, PathString, Root } from '../path';
 import { Operation } from '../operation';
 
 /**
@@ -10,15 +10,15 @@ import { Operation } from '../operation';
  */
 export function isTaskApplicable<
 	TState = any,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 >(t: Task<TState, TPath, TOp>, o: Operation<any, any>) {
 	if (t.op !== '*' && t.op !== o.op) {
 		return false;
 	}
 
-	const taskParts = Path.elems(t.lens);
-	const opParts = Path.elems(o.path);
+	const taskParts = Path.split(t.lens);
+	const opParts = Path.split(o.path);
 
 	if (taskParts.length !== opParts.length) {
 		return false;

--- a/lib/pointer.ts
+++ b/lib/pointer.ts
@@ -1,18 +1,21 @@
-import { Path } from './path';
+import { Path, PathString, Root } from './path';
 import { isArrayIndex } from './is-array-index';
 
-export type Pointer<O, P extends Path> = PointerWithSlash<O, P>;
+export type Pointer<O, P extends PathString> = PointerWithSlash<O, P>;
 
-type PointerWithSlash<O, P extends Path> = P extends `/${infer R}`
+type PointerWithSlash<O, P extends PathString> = P extends `/${infer R}`
 	? PointerWithoutSlash<O, R>
-	: never;
-type PointerWithoutSlash<O, P extends Path> = P extends `${infer H}/${infer T}`
+	: unknown;
+type PointerWithoutSlash<
+	O,
+	P extends PathString,
+> = P extends `${infer H}/${infer T}`
 	? PointerWithCompoundPath<O, H, T>
 	: PointerWithSinglePath<O, P>;
 type PointerWithCompoundPath<
 	O,
 	H extends string,
-	T extends Path,
+	T extends PathString,
 > = O extends any[]
 	? PointerWithoutSlash<O[number], T>
 	: H extends keyof O
@@ -25,19 +28,18 @@ type PointerWithSinglePath<O, H extends string> = O extends any[]
 	  : never;
 
 export class InvalidPointer extends Error {
-	constructor(path: Path, obj: unknown) {
+	constructor(path: PathString, obj: unknown) {
 		super(
 			`Path ${path} is not a valid pointer for object ${JSON.stringify(obj)}`,
 		);
 	}
 }
 
-function from<O = any, P extends Path = '/'>(
+function from<O = any, P extends PathString = Root>(
 	obj: O,
-	path: P,
+	path: Path<P>,
 ): Pointer<O, P> | undefined {
-	Path.assert(path);
-	const parts = Path.elems(path);
+	const parts = Path.split(path);
 
 	let o = obj as any;
 	for (const p of parts) {
@@ -61,5 +63,5 @@ function from<O = any, P extends Path = '/'>(
 }
 
 export const Pointer = {
-	from: from,
+	from,
 };

--- a/lib/sensor.ts
+++ b/lib/sensor.ts
@@ -1,5 +1,5 @@
 import { Lens } from './lens';
-import { Path } from './path';
+import { Path, PathString } from './path';
 import { Ref } from './ref';
 import { View } from './view';
 
@@ -23,7 +23,7 @@ export type Sensor<T> = (s: Ref<T>) => Subscribable<T>;
 /**
  * The sensor constructor properties
  */
-export interface SensorProps<T, P extends Path = '/'> {
+export interface SensorProps<T, P extends PathString = '/'> {
 	/**
 	 * A lens to indicate what part of the state the sensor
 	 * will update as it runs. Unlike task lense, sensor lenses
@@ -46,7 +46,7 @@ export interface SensorProps<T, P extends Path = '/'> {
  * If a function is passed, it is assumed to be the `sensor` function, and
  * the `lens` is assumed to be the root of the state.
  */
-function from<T, P extends Path = '/'>(
+function from<T, P extends PathString = '/'>(
 	input: SensorFn<Lens<T, P>> | Partial<SensorProps<T, P>>,
 ): Sensor<T> {
 	const {
@@ -56,7 +56,7 @@ function from<T, P extends Path = '/'>(
 		},
 	} = typeof input === 'function' ? { sensor: input } : input;
 	return function (s) {
-		const view = View.from(s, lens);
+		const view = View.from(s, Path.from(lens));
 
 		return Observable.from(sensor()).map((value) => {
 			// For each value emmited by the sensor
@@ -77,7 +77,7 @@ function from<T, P extends Path = '/'>(
  * the same type.
  */
 interface SensorBuilder<T> {
-	from<P extends Path = '/'>(t: SensorProps<T, P>): Sensor<T>;
+	from<P extends PathString = '/'>(t: SensorProps<T, P>): Sensor<T>;
 }
 
 function of<T>(): SensorBuilder<T> {

--- a/lib/task/context.ts
+++ b/lib/task/context.ts
@@ -1,5 +1,5 @@
 import { Op } from '../operation';
-import { Path } from '../path';
+import { PathString, Root } from '../path';
 import { Identity } from '../identity';
 import { LensContext } from '../lens';
 
@@ -24,7 +24,11 @@ export type TaskOp = Op | '*';
  *  set(s, get(s)) = s
  *  set(set(s, a), a) = set(s,a)
  */
-export type Context<TState, TPath extends Path, TOp extends TaskOp> = Identity<
+export type Context<
+	TState,
+	TPath extends PathString,
+	TOp extends TaskOp,
+> = Identity<
 	TOp extends '*' | 'delete'
 		? Omit<LensContext<TState, TPath>, 'target'>
 		: LensContext<TState, TPath>
@@ -33,11 +37,11 @@ export type Context<TState, TPath extends Path, TOp extends TaskOp> = Identity<
 // Redeclare the type for exporting
 export type TaskArgs<
 	TState = any,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 > = Identity<Omit<Context<TState, TPath, TOp>, 'path'>>;
 
-function from<TState, TPath extends Path, TOp extends TaskOp>(
+function from<TState, TPath extends PathString, TOp extends TaskOp>(
 	lensCtx: LensContext<TState, TPath>,
 ): Context<TState, TPath, TOp> {
 	return lensCtx as any;

--- a/lib/task/helpers.ts
+++ b/lib/task/helpers.ts
@@ -1,5 +1,5 @@
 import { Context, TaskOp } from './context';
-import { Path } from '../path';
+import { PathString, Root } from '../path';
 import { Action } from './instructions';
 
 export const NoAction = async () => void 0;
@@ -11,7 +11,7 @@ export const NoEffect = () => void 0;
  */
 export function NoOp<
 	TState = any,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = '*',
 >(ctx: Context<TState, TPath, TOp>): Action<TState> {
 	return Object.assign(NoAction, {

--- a/lib/task/helpers.ts
+++ b/lib/task/helpers.ts
@@ -17,7 +17,7 @@ export function NoOp<
 	return Object.assign(NoAction, {
 		_tag: 'action' as const,
 		id: 'noop',
-		path: ctx.path as TPath,
+		path: ctx.path,
 		target: (ctx as any).target,
 		description: 'no-op',
 		effect: NoEffect,

--- a/lib/task/instructions.ts
+++ b/lib/task/instructions.ts
@@ -1,8 +1,8 @@
-import { Path } from '../path';
+import { Path, PathString } from '../path';
 import { TaskOp, Context } from './context';
 import { Ref } from '../ref';
 
-interface Instance<TState, TPath extends Path, TOp extends TaskOp> {
+interface Instance<TState, TPath extends PathString, TOp extends TaskOp> {
 	/**
 	 * The identifier for the task
 	 */
@@ -11,7 +11,7 @@ interface Instance<TState, TPath extends Path, TOp extends TaskOp> {
 	/**
 	 * The actual path that this instance applies to
 	 */
-	readonly path: TPath;
+	readonly path: Path<TPath>;
 
 	/**
 	 * The target for the instruction
@@ -34,7 +34,7 @@ interface Instance<TState, TPath extends Path, TOp extends TaskOp> {
 /** An action task that has been applied to a specific context */
 export interface Action<
 	TState = any,
-	TPath extends Path = any,
+	TPath extends PathString = any,
 	TOp extends TaskOp = any,
 > extends Instance<TState, TPath, TOp> {
 	readonly _tag: 'action';
@@ -57,7 +57,7 @@ export type MethodExpansion =
 /** A method task that has been applied to a specific context */
 export interface Method<
 	TState = any,
-	TPath extends Path = any,
+	TPath extends PathString = any,
 	TOp extends TaskOp = any,
 > extends Instance<TState, TPath, TOp> {
 	readonly _tag: 'method';
@@ -80,7 +80,7 @@ export interface Method<
 
 export type Instruction<
 	TState = any,
-	TPath extends Path = any,
+	TPath extends PathString = any,
 	TOp extends TaskOp = any,
 > = Action<TState, TPath, TOp> | Method<TState, TPath, TOp>;
 

--- a/lib/task/tasks.spec.ts
+++ b/lib/task/tasks.spec.ts
@@ -11,7 +11,7 @@ describe('Tasks', () => {
 			description: '+1',
 		});
 		expect(inc.id).to.equal(
-			'9d73c72d26c1bbb33a4ee484e399129fcab792122a52a5816f1e0ef20dfc47ec',
+			'cbc6726f9c9afc51b7ef2356bc640663e77fbee26a50808cb3fd0355ab7dd043',
 		);
 
 		const inc2 = Task.from<number>({
@@ -41,7 +41,7 @@ describe('Tasks', () => {
 			description: '+2',
 		});
 		expect(byTwo.id).to.equal(
-			'e6ae37e6ef05cc2ee70493842cd1799aeeec8867c6efd15b1b1f1bca96436a48',
+			'7e3d92c6d21f4f0e63d3b3f2b571fdb5e7424a670d14718a23e2dd2d0588eddd',
 		);
 		expect(dec.id).to.not.equal(byTwo.id);
 

--- a/lib/task/tasks.ts
+++ b/lib/task/tasks.ts
@@ -3,7 +3,7 @@ import { createHash } from 'crypto';
 import assert from '../assert';
 import { Context, TaskArgs, TaskOp } from './context';
 import { Lens } from '../lens';
-import { Path } from '../path';
+import { Path, PathString, Root } from '../path';
 import { Ref } from '../ref';
 import { View } from '../view';
 
@@ -11,7 +11,7 @@ import { Action, Instruction, Method, MethodExpansion } from './instructions';
 
 type TaskContext<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 > = Context<TState, TPath, TOp> & { system: TState };
 
@@ -20,7 +20,7 @@ type TaskContext<
  */
 interface TaskSpec<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 > {
 	/**
@@ -39,7 +39,7 @@ interface TaskSpec<
 	/**
 	 * The path to the element that this task applies to
 	 */
-	readonly lens: TPath;
+	readonly lens: Path<TPath>;
 
 	/**
 	 * The operation that this task applies to
@@ -61,7 +61,7 @@ interface TaskSpec<
  */
 interface ActionSpec<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 > extends TaskSpec<TState, TPath, TOp> {
 	/**
@@ -154,7 +154,7 @@ interface ActionSpec<
  */
 export interface ActionTask<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 > extends ActionSpec<TState, TPath, TOp> {
 	/**
@@ -173,7 +173,7 @@ export interface ActionTask<
 // A method definition
 export interface MethodSpec<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 > extends TaskSpec<TState, TPath, TOp> {
 	/**
@@ -223,7 +223,7 @@ export interface MethodSpec<
  */
 export interface MethodTask<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 > extends MethodSpec<TState, TPath, TOp> {
 	/**
@@ -242,31 +242,29 @@ export interface MethodTask<
 // Bind a task to a specific context
 function ground<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 >(
 	task: ActionSpec<TState, TPath, TOp> | MethodSpec<TState, TPath, TOp>,
 	args: TaskArgs<TState, TPath, TOp>,
 ): Instruction<TState, TPath, TOp> {
-	const templateParts = Path.elems(task.lens);
+	const templateParts = Path.split(task.lens);
 
 	// Form the context path from the task lens and the
 	// given task arguments
-	const path =
-		'/' +
-		templateParts
-			.map((p) => {
-				if (p.startsWith(':')) {
-					const key = p.slice(1);
-					assert(
-						key in args,
-						`Missing parameter '${key}' in context given to task '${task.id}', required by lens '${task.lens}'`,
-					);
-					return args[key as keyof typeof args];
-				}
-				return p;
-			})
-			.join('/');
+	const path = Path.from(
+		templateParts.map((p) => {
+			if (p.startsWith(':')) {
+				const key = p.slice(1);
+				assert(
+					key in args,
+					`Missing parameter '${key}' in context given to task '${task.id}', required by lens '${task.lens}'`,
+				);
+				return String(args[key as keyof typeof args]);
+			}
+			return p;
+		}),
+	) as Path<TPath>;
 
 	const target = (args as any).target;
 	const lensCtx = Lens.context<TState, TPath>(task.lens, path, target);
@@ -279,7 +277,7 @@ function ground<
 			: taskDescription;
 
 	const condition = (s: TState) => {
-		const lens = Lens.from(s, path as TPath);
+		const lens = Lens.from(s, path);
 		return task.condition(lens, {
 			...context,
 			system: s,
@@ -289,12 +287,12 @@ function ground<
 	if (isActionSpec(task)) {
 		const { effect: taskEffect, action: taskAction } = task;
 		const effect = (s: Ref<TState>) =>
-			taskEffect(View.from(s, path as TPath), { ...context, system: s._ });
+			taskEffect(View.from(s, path), { ...context, system: s._ });
 		const action = async (s: Ref<TState>) =>
-			taskAction(View.from(s, path as TPath), { ...context, system: s._ });
+			taskAction(View.from(s, path), { ...context, system: s._ });
 		return Object.assign(action, {
 			id,
-			path: context.path as TPath,
+			path: context.path,
 			target,
 			_tag: 'action' as const,
 			description,
@@ -313,7 +311,10 @@ function ground<
 
 	const { expansion } = task;
 	const method = (s: TState) =>
-		task.method(Lens.from(s, context.path as TPath), { ...context, system: s });
+		task.method(Lens.from(s, context.path as Path<TPath>), {
+			...context,
+			system: s,
+		});
 
 	return Object.assign(method, {
 		id,
@@ -339,7 +340,7 @@ function ground<
  */
 function isActionSpec<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 >(
 	t: ActionSpec<TState, TPath, TOp> | MethodSpec<TState, TPath, TOp>,
@@ -357,7 +358,7 @@ function isActionSpec<
  */
 function isMethodTask<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 >(t: Task<TState, TPath, TOp>): t is MethodTask<TState, TPath, TOp> {
 	return (t as any).method != null && typeof (t as any).method === 'function';
@@ -368,7 +369,7 @@ function isMethodTask<
  */
 function isActionTask<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 >(t: Task<TState, TPath, TOp>): t is ActionTask<TState, TPath, TOp> {
 	return (
@@ -384,7 +385,7 @@ function isActionTask<
  */
 export type Task<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 > = ActionTask<TState, TPath, TOp> | MethodTask<TState, TPath, TOp>;
 
@@ -393,27 +394,27 @@ export type Task<
  */
 export type MethodTaskProps<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
-> = Partial<Omit<MethodSpec<TState, TPath, TOp>, 'method' | 'id'>> &
-	Pick<MethodSpec<TState, TPath, TOp>, 'method'>;
+> = Partial<Omit<MethodSpec<TState, TPath, TOp>, 'method' | 'id' | 'lens'>> &
+	Pick<MethodSpec<TState, TPath, TOp>, 'method'> & { lens?: TPath };
 
 /**
  * Action task properties for the task constructor
  */
 export type ActionTaskProps<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 > =
-	| (Partial<Omit<ActionSpec<TState, TPath, TOp>, 'effect' | 'id'>> &
-			Pick<ActionSpec<TState, TPath, TOp>, 'effect'>)
-	| (Partial<Omit<ActionSpec<TState, TPath, TOp>, 'action' | 'id'>> &
-			Pick<ActionSpec<TState, TPath, TOp>, 'action'>);
+	| ((Partial<Omit<ActionSpec<TState, TPath, TOp>, 'effect' | 'id' | 'lens'>> &
+			Pick<ActionSpec<TState, TPath, TOp>, 'effect'>) & { lens?: TPath })
+	| ((Partial<Omit<ActionSpec<TState, TPath, TOp>, 'action' | 'id' | 'lens'>> &
+			Pick<ActionSpec<TState, TPath, TOp>, 'action'>) & { lens?: TPath });
 
 function isActionProps<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 >(
 	x: ActionTaskProps<TState, TPath, TOp> | MethodTaskProps<TState, TPath, TOp>,
@@ -429,31 +430,27 @@ function isActionProps<
  */
 function from<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 >(t: ActionTaskProps<TState, TPath, TOp>): ActionTask<TState, TPath, TOp>;
 function from<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 >(t: MethodTaskProps<TState, TPath, TOp>): MethodTask<TState, TPath, TOp>;
 function from<
 	TState = unknown,
-	TPath extends Path = '/',
+	TPath extends PathString = Root,
 	TOp extends TaskOp = 'update',
 >(
 	taskProps:
 		| ActionTaskProps<TState, TPath, TOp>
 		| MethodTaskProps<TState, TPath, TOp>,
 ) {
-	const {
-		lens = '/',
-		op = 'update',
-		condition: taskCondition = () => true,
-	} = taskProps;
+	const { op = 'update', condition: taskCondition = () => true } = taskProps;
 
 	// Check that the path is valid
-	Path.assert(lens);
+	const lens = Path.from(taskProps.lens || ('/' as TPath));
 
 	const opLabel = op === '*' ? 'modify' : op;
 
@@ -521,9 +518,9 @@ function from<
 
 			return {
 				description,
-				lens: lens as TPath,
 				op: op as TOp,
 				...taskProps,
+				lens,
 				condition,
 				effect,
 				action,
@@ -531,10 +528,10 @@ function from<
 		} else {
 			return {
 				description,
-				lens: lens as TPath,
 				op: op as TOp,
 				expansion: MethodExpansion.DETECT,
 				...taskProps,
+				lens,
 				condition,
 			};
 		}
@@ -565,10 +562,10 @@ function from<
 }
 
 interface TaskBuilder<TState> {
-	from<TPath extends Path = '/', TOp extends TaskOp = 'update'>(
+	from<TPath extends PathString = Root, TOp extends TaskOp = 'update'>(
 		t: ActionTaskProps<TState, TPath, TOp>,
 	): ActionTask<TState, TPath, TOp>;
-	from<TPath extends Path = '/', TOp extends TaskOp = 'update'>(
+	from<TPath extends PathString = Root, TOp extends TaskOp = 'update'>(
 		t: MethodTaskProps<TState, TPath, TOp>,
 	): MethodTask<TState, TPath, TOp>;
 }

--- a/lib/task/tasks.ts
+++ b/lib/task/tasks.ts
@@ -292,7 +292,7 @@ function ground<
 			taskAction(View.from(s, path), { ...context, system: s._ });
 		return Object.assign(action, {
 			id,
-			path: context.path,
+			path: context.path as Path<TPath>,
 			target,
 			_tag: 'action' as const,
 			description,

--- a/lib/testing/mermaid.spec.ts
+++ b/lib/testing/mermaid.spec.ts
@@ -60,14 +60,14 @@ describe('Mermaid', () => {
 			graph TD
 				start(( ))
 				start -.- d0{ }
-				d0 -.- 1b61d85("+1")
-				1b61d85 -.- stop(( ))
+				d0 -.- eb35387("+1")
+				eb35387 -.- stop(( ))
 				stop:::finish
 				classDef finish stroke:#000,fill:#000
 				start:::selected
-				start --> 1b61d85
-				1b61d85:::selected
-				1b61d85 --> stop
+				start --> eb35387
+				eb35387:::selected
+				eb35387 --> stop
 				classDef error stroke:#f00
 				classDef selected stroke:#0f0
 			`.trim(),
@@ -100,17 +100,17 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- 430b5ac("-1")
-					430b5ac -.- 430b5ac-err[ ]
-					430b5ac-err:::error
-					d0 -.- 1b61d85("+1")
-					1b61d85 -.- stop(( ))
+					d0 -.- 34364f2("-1")
+					34364f2 -.- 34364f2-err[ ]
+					34364f2-err:::error
+					d0 -.- eb35387("+1")
+					eb35387 -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> 1b61d85
-					1b61d85:::selected
-					1b61d85 --> stop
+					start --> eb35387
+					eb35387:::selected
+					eb35387 --> stop
 					classDef error stroke:#f00
 					classDef selected stroke:#0f0
 				`.trim(),
@@ -134,21 +134,21 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- 32215d7("+1")
-					32215d7 -.- d1{ }
-					d1 -.- bb43ece("+1")
-					bb43ece -.- stop(( ))
+					d0 -.- ede85fb("+1")
+					ede85fb -.- d1{ }
+					d1 -.- 8d85823("+1")
+					8d85823 -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> 32215d7
-					32215d7:::selected
-					32215d7 --> bb43ece
-					bb43ece:::selected
-					bb43ece --> stop
+					start --> ede85fb
+					ede85fb:::selected
+					ede85fb --> 8d85823
+					8d85823:::selected
+					8d85823 --> stop
 					classDef error stroke:#f00
 					classDef selected stroke:#0f0
-			`.trim(),
+				`.trim(),
 		);
 	});
 
@@ -178,24 +178,24 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- 90d01a4("-1")
-					90d01a4 -.- 90d01a4-err[ ]
-					90d01a4-err:::error
-					d0 -.- 32215d7("+1")
-					32215d7 -.- d1{ }
-					d1 -.- 3f3fe30("-1")
-					3f3fe30 -.- 3f3fe30-err[ ]
-					3f3fe30-err:::error
-					d1 -.- bb43ece("+1")
-					bb43ece -.- stop(( ))
+					d0 -.- deeb466("-1")
+					deeb466 -.- deeb466-err[ ]
+					deeb466-err:::error
+					d0 -.- ede85fb("+1")
+					ede85fb -.- d1{ }
+					d1 -.- 6eaa8d5("-1")
+					6eaa8d5 -.- 6eaa8d5-err[ ]
+					6eaa8d5-err:::error
+					d1 -.- 8d85823("+1")
+					8d85823 -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> 32215d7
-					32215d7:::selected
-					32215d7 --> bb43ece
-					bb43ece:::selected
-					bb43ece --> stop
+					start --> ede85fb
+					ede85fb:::selected
+					ede85fb --> 8d85823
+					8d85823:::selected
+					8d85823 --> stop
 					classDef error stroke:#f00
 					classDef selected stroke:#0f0
 				`.trim(),
@@ -228,17 +228,17 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- 85ff46f[["+2"]]
-					85ff46f -.- 85ff46f-err[ ]
-					85ff46f-err:::error
-					d0 -.- 1b61d85("+1")
-					1b61d85 -.- stop(( ))
+					d0 -.- cef8b47[["+2"]]
+					cef8b47 -.- cef8b47-err[ ]
+					cef8b47-err:::error
+					d0 -.- eb35387("+1")
+					eb35387 -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> 1b61d85
-					1b61d85:::selected
-					1b61d85 --> stop
+					start --> eb35387
+					eb35387:::selected
+					eb35387 --> stop
 					classDef error stroke:#f00
 					classDef selected stroke:#0f0
 				`.trim(),
@@ -271,25 +271,25 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- afa7c77[["+2"]]
-					afa7c77 -.- 1d5c604("+1")
-					1d5c604 -.- e4545aa("+1")
-					e4545aa -.- d1{ }
-					d1 -.- 5a8d071[["+2"]]
-					5a8d071 -.- 5a8d071-err[ ]
-					5a8d071-err:::error
-					d1 -.- 6ba514a("+1")
-					6ba514a -.- stop(( ))
+					d0 -.- 7ade865[["+2"]]
+					7ade865 -.- d91038f("+1")
+					d91038f -.- 56dee17("+1")
+					56dee17 -.- d1{ }
+					d1 -.- 9272fd8[["+2"]]
+					9272fd8 -.- 9272fd8-err[ ]
+					9272fd8-err:::error
+					d1 -.- 6d61260("+1")
+					6d61260 -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> 1d5c604
-					1d5c604:::selected
-					1d5c604 --> e4545aa
-					e4545aa:::selected
-					e4545aa --> 6ba514a
-					6ba514a:::selected
-					6ba514a --> stop
+					start --> d91038f
+					d91038f:::selected
+					d91038f --> 56dee17
+					56dee17:::selected
+					56dee17 --> 6d61260
+					6d61260:::selected
+					6d61260 --> stop
 					classDef error stroke:#f00
 					classDef selected stroke:#0f0
 				`.trim(),
@@ -332,44 +332,44 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- e1410cd[["+3"]]
-					e1410cd -.- ced9af0[["+2"]]
-					ced9af0 -.- 180733b("+1")
-					180733b -.- 9c0697d("+1")
-					9c0697d -.- 4402352("+1")
-					4402352 -.- d1{ }
-					d1 -.- 5180f6e[["+3"]]
-					5180f6e -.- 193c573[["+2"]]
-					193c573 -.- 6653d29("+1")
-					6653d29 -.- 5e028cf("+1")
-					5e028cf -.- 8efc9e4("+1")
-					8efc9e4 -.- d2{ }
-					d2 -.- 97cf280[["+3"]]
-					97cf280 -.- 97cf280-err[ ]
-					97cf280-err:::error
-					d2 -.- 5800777[["+2"]]
-					5800777 -.- 5800777-err[ ]
-					5800777-err:::error
-					d2 -.- b71bed1("+1")
-					b71bed1 -.- stop(( ))
+					d0 -.- 8ddddab[["+3"]]
+					8ddddab -.- 60ade34[["+2"]]
+					60ade34 -.- fa032ee("+1")
+					fa032ee -.- af13cc0("+1")
+					af13cc0 -.- b11100d("+1")
+					b11100d -.- d1{ }
+					d1 -.- 64101c2[["+3"]]
+					64101c2 -.- e8f3079[["+2"]]
+					e8f3079 -.- a28edfc("+1")
+					a28edfc -.- 467594f("+1")
+					467594f -.- 994a0c9("+1")
+					994a0c9 -.- d2{ }
+					d2 -.- 92c1c3f[["+3"]]
+					92c1c3f -.- 92c1c3f-err[ ]
+					92c1c3f-err:::error
+					d2 -.- db08bc1[["+2"]]
+					db08bc1 -.- db08bc1-err[ ]
+					db08bc1-err:::error
+					d2 -.- 593c362("+1")
+					593c362 -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> 180733b
-					180733b:::selected
-					180733b --> 9c0697d
-					9c0697d:::selected
-					9c0697d --> 4402352
-					4402352:::selected
-					4402352 --> 6653d29
-					6653d29:::selected
-					6653d29 --> 5e028cf
-					5e028cf:::selected
-					5e028cf --> 8efc9e4
-					8efc9e4:::selected
-					8efc9e4 --> b71bed1
-					b71bed1:::selected
-					b71bed1 --> stop
+					start --> fa032ee
+					fa032ee:::selected
+					fa032ee --> af13cc0
+					af13cc0:::selected
+					af13cc0 --> b11100d
+					b11100d:::selected
+					b11100d --> a28edfc
+					a28edfc:::selected
+					a28edfc --> 467594f
+					467594f:::selected
+					467594f --> 994a0c9
+					994a0c9:::selected
+					994a0c9 --> 593c362
+					593c362:::selected
+					593c362 --> stop
 					classDef error stroke:#f00
 					classDef selected stroke:#0f0
 			`,
@@ -409,54 +409,53 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- 8dd5003[["increment counters"]]
-					8dd5003 -.- 5bb6c18("a + 1")
-					8dd5003 -.- 9c5d478("b + 1")
-					5bb6c18 -.- j7272a3d
-					9c5d478 -.- j7272a3d
-					j7272a3d(( ))
-					j7272a3d -.- d1{ }
-					d1 -.- 2fb608a[["increment counters"]]
-					2fb608a -.- a5d1149("a + 1")
-					2fb608a -.- 9578070("b + 1")
-					a5d1149 -.- jde6ad08
-					9578070 -.- jde6ad08
-					jde6ad08(( ))
-					jde6ad08 -.- d2{ }
-					d2 -.- 8abf853[["increment counters"]]
-					8abf853 -.- 8abf853-err[ ]
-					8abf853-err:::error
-					d2 -.- 05e1e95("a + 1")
-					05e1e95 -.- stop(( ))
+					d0 -.- f1e6082[["increment counters"]]
+					f1e6082 -.- bc81372("a + 1")
+					f1e6082 -.- 745bd1f("b + 1")
+					bc81372 -.- jf4e90eb
+					745bd1f -.- jf4e90eb
+					jf4e90eb(( ))
+					jf4e90eb -.- d1{ }
+					d1 -.- 724e914[["increment counters"]]
+					724e914 -.- e152e9e("a + 1")
+					724e914 -.- ef0db09("b + 1")
+					e152e9e -.- j8578a7d
+					ef0db09 -.- j8578a7d
+					j8578a7d(( ))
+					j8578a7d -.- d2{ }
+					d2 -.- 638942b[["increment counters"]]
+					638942b -.- 638942b-err[ ]
+					638942b-err:::error
+					d2 -.- 4f3358f("a + 1")
+					4f3358f -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> fj7272a3d(( ))
-					fj7272a3d:::selected
-					fj7272a3d --> 5bb6c18
-					5bb6c18:::selected
-					fj7272a3d --> 9c5d478
-					9c5d478:::selected
-					j7272a3d(( ))
-					5bb6c18 --> j7272a3d
-					9c5d478 --> j7272a3d
-					j7272a3d:::selected
-					j7272a3d --> fjde6ad08(( ))
-					fjde6ad08:::selected
-					fjde6ad08 --> a5d1149
-					a5d1149:::selected
-					fjde6ad08 --> 9578070
-					9578070:::selected
-					jde6ad08(( ))
-					a5d1149 --> jde6ad08
-					9578070 --> jde6ad08
-					jde6ad08:::selected
-					jde6ad08 --> 05e1e95
-					05e1e95:::selected
-					05e1e95 --> stop
+					start --> fjf4e90eb(( ))
+					fjf4e90eb:::selected
+					fjf4e90eb --> bc81372
+					bc81372:::selected
+					fjf4e90eb --> 745bd1f
+					745bd1f:::selected
+					jf4e90eb(( ))
+					bc81372 --> jf4e90eb
+					745bd1f --> jf4e90eb
+					jf4e90eb:::selected
+					jf4e90eb --> fj8578a7d(( ))
+					fj8578a7d:::selected
+					fj8578a7d --> e152e9e
+					e152e9e:::selected
+					fj8578a7d --> ef0db09
+					ef0db09:::selected
+					j8578a7d(( ))
+					e152e9e --> j8578a7d
+					ef0db09 --> j8578a7d
+					j8578a7d:::selected
+					j8578a7d --> 4f3358f
+					4f3358f:::selected
+					4f3358f --> stop
 					classDef error stroke:#f00
-					classDef selected stroke:#0f0
-			`,
+					classDef selected stroke:#0f0			`,
 		);
 	});
 
@@ -498,45 +497,45 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- 6155512[["increment counters"]]
-					6155512 -.- 9ea56ac[["increase 'a'"]]
-					9ea56ac -.- 27fff9e("a + 1")
-					27fff9e -.- 0e3f56c("a + 1")
-					6155512 -.- 5003b21[["increase 'b'"]]
-					5003b21 -.- de69aab("b + 1")
-					de69aab -.- 0bf9a34("b + 1")
-					0e3f56c -.- jde6ad08
-					0bf9a34 -.- jde6ad08
-					jde6ad08(( ))
-					jde6ad08 -.- d1{ }
-					d1 -.- 3311fc0[["increment counters"]]
-					3311fc0 -.- 3311fc0-err[ ]
-					3311fc0-err:::error
-					d1 -.- a9c52c6[["increase 'a'"]]
-					a9c52c6 -.- a9c52c6-err[ ]
-					a9c52c6-err:::error
-					d1 -.- eb5cff4("a + 1")
-					eb5cff4 -.- stop(( ))
+					d0 -.- 473c818[["increment counters"]]
+					473c818 -.- 4da4b47[["increase 'a'"]]
+					4da4b47 -.- a9ef90e("a + 1")
+					a9ef90e -.- 7379b58("a + 1")
+					473c818 -.- fb667a2[["increase 'b'"]]
+					fb667a2 -.- 1a61a0b("b + 1")
+					1a61a0b -.- 619482f("b + 1")
+					7379b58 -.- j8578a7d
+					619482f -.- j8578a7d
+					j8578a7d(( ))
+					j8578a7d -.- d1{ }
+					d1 -.- b0d92d4[["increment counters"]]
+					b0d92d4 -.- b0d92d4-err[ ]
+					b0d92d4-err:::error
+					d1 -.- 03f7700[["increase 'a'"]]
+					03f7700 -.- 03f7700-err[ ]
+					03f7700-err:::error
+					d1 -.- 7518c42("a + 1")
+					7518c42 -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> fj7272a3d(( ))
-					fj7272a3d:::selected
-					fj7272a3d --> 27fff9e
-					27fff9e:::selected
-					27fff9e --> 0e3f56c
-					0e3f56c:::selected
-					fj7272a3d --> de69aab
-					de69aab:::selected
-					de69aab --> 0bf9a34
-					0bf9a34:::selected
-					j7272a3d(( ))
-					0e3f56c --> j7272a3d
-					0bf9a34 --> j7272a3d
-					j7272a3d:::selected
-					j7272a3d --> eb5cff4
-					eb5cff4:::selected
-					eb5cff4 --> stop
+					start --> fjf4e90eb(( ))
+					fjf4e90eb:::selected
+					fjf4e90eb --> a9ef90e
+					a9ef90e:::selected
+					a9ef90e --> 7379b58
+					7379b58:::selected
+					fjf4e90eb --> 1a61a0b
+					1a61a0b:::selected
+					1a61a0b --> 619482f
+					619482f:::selected
+					jf4e90eb(( ))
+					7379b58 --> jf4e90eb
+					619482f --> jf4e90eb
+					jf4e90eb:::selected
+					jf4e90eb --> 7518c42
+					7518c42:::selected
+					7518c42 --> stop
 					classDef error stroke:#f00
 					classDef selected stroke:#0f0
 				`,
@@ -611,83 +610,82 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- ac8cc3a[["chunk"]]
-					ac8cc3a -.- b2fcf21[["increment multiple"]]
-					b2fcf21 -.- 9ef9ead[["a + 2"]]
-					9ef9ead -.- c5037ba("a++")
-					c5037ba -.- 39337c1("a++")
-					b2fcf21 -.- 332010e[["b + 2"]]
-					332010e -.- 034bbe0("b++")
-					034bbe0 -.- 20ee506("b++")
-					ac8cc3a -.- bf2a438[["increment multiple"]]
-					bf2a438 -.- 8ec14bf[["c + 2"]]
-					8ec14bf -.- 9313895("c++")
-					9313895 -.- 9483746("c++")
-					bf2a438 -.- 7093746[["d + 2"]]
-					7093746 -.- 98a9a34("d++")
-					98a9a34 -.- d36adcb("d++")
-					39337c1 -.- j2b2a51d
-					20ee506 -.- j2b2a51d
-					j2b2a51d(( )) -.- 4fa0388
-					9483746 -.- j02d8902
-					d36adcb -.- j02d8902
-					j02d8902(( )) -.- 4fa0388
-					4fa0388(( ))
-					4fa0388 -.- d1{ }
-					d1 -.- fd65f2e[["chunk"]]
-					fd65f2e -.- fd65f2e-err[ ]
-					fd65f2e-err:::error
-					d1 -.- 6571c52[["increment multiple"]]
-					6571c52 -.- 6571c52-err[ ]
-					6571c52-err:::error
-					d1 -.- df8fad6[["a + 2"]]
-					df8fad6 -.- df8fad6-err[ ]
-					df8fad6-err:::error
-					d1 -.- b715c94("a++")
-					b715c94 -.- stop(( ))
+					d0 -.- 95a2b94[["chunk"]]
+					95a2b94 -.- 7d0d5d2[["increment multiple"]]
+					7d0d5d2 -.- fb6e56f[["a + 2"]]
+					fb6e56f -.- 9a38b55("a++")
+					9a38b55 -.- 61d794a("a++")
+					7d0d5d2 -.- 0998b72[["b + 2"]]
+					0998b72 -.- f4f729d("b++")
+					f4f729d -.- 1afee5b("b++")
+					95a2b94 -.- 853d3ae[["increment multiple"]]
+					853d3ae -.- 11839b9[["c + 2"]]
+					11839b9 -.- f169d20("c++")
+					f169d20 -.- 9f5c731("c++")
+					853d3ae -.- f4a70f2[["d + 2"]]
+					f4a70f2 -.- fa111f1("d++")
+					fa111f1 -.- 02175b1("d++")
+					61d794a -.- jfdbd0fe
+					1afee5b -.- jfdbd0fe
+					jfdbd0fe(( )) -.- 1f2d05c
+					9f5c731 -.- jf0c2aca
+					02175b1 -.- jf0c2aca
+					jf0c2aca(( )) -.- 1f2d05c
+					1f2d05c(( ))
+					1f2d05c -.- d1{ }
+					d1 -.- c978cdc[["chunk"]]
+					c978cdc -.- c978cdc-err[ ]
+					c978cdc-err:::error
+					d1 -.- 9266c34[["increment multiple"]]
+					9266c34 -.- 9266c34-err[ ]
+					9266c34-err:::error
+					d1 -.- 1f7243e[["a + 2"]]
+					1f7243e -.- 1f7243e-err[ ]
+					1f7243e-err:::error
+					d1 -.- 4ca63a1("a++")
+					4ca63a1 -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> f304966c(( ))
-					f304966c:::selected
-					f304966c --> fj5213432(( ))
-					fj5213432:::selected
-					fj5213432 --> c5037ba
-					c5037ba:::selected
-					c5037ba --> 39337c1
-					39337c1:::selected
-					fj5213432 --> 034bbe0
-					034bbe0:::selected
-					034bbe0 --> 20ee506
-					20ee506:::selected
-					j5213432(( ))
-					39337c1 --> j5213432
-					20ee506 --> j5213432
-					j5213432:::selected
-					f304966c --> fj316bfe2(( ))
-					fj316bfe2:::selected
-					fj316bfe2 --> 9313895
-					9313895:::selected
-					9313895 --> 9483746
-					9483746:::selected
-					fj316bfe2 --> 98a9a34
-					98a9a34:::selected
-					98a9a34 --> d36adcb
-					d36adcb:::selected
-					j316bfe2(( ))
-					9483746 --> j316bfe2
-					d36adcb --> j316bfe2
-					j316bfe2:::selected
-					304966c(( ))
-					j5213432 --> 304966c
-					j316bfe2 --> 304966c
-					304966c:::selected
-					304966c --> b715c94
-					b715c94:::selected
-					b715c94 --> stop
+					start --> f9648dae(( ))
+					f9648dae:::selected
+					f9648dae --> fj40f95ac(( ))
+					fj40f95ac:::selected
+					fj40f95ac --> 9a38b55
+					9a38b55:::selected
+					9a38b55 --> 61d794a
+					61d794a:::selected
+					fj40f95ac --> f4f729d
+					f4f729d:::selected
+					f4f729d --> 1afee5b
+					1afee5b:::selected
+					j40f95ac(( ))
+					61d794a --> j40f95ac
+					1afee5b --> j40f95ac
+					j40f95ac:::selected
+					f9648dae --> fjcc7ed51(( ))
+					fjcc7ed51:::selected
+					fjcc7ed51 --> f169d20
+					f169d20:::selected
+					f169d20 --> 9f5c731
+					9f5c731:::selected
+					fjcc7ed51 --> fa111f1
+					fa111f1:::selected
+					fa111f1 --> 02175b1
+					02175b1:::selected
+					jcc7ed51(( ))
+					9f5c731 --> jcc7ed51
+					02175b1 --> jcc7ed51
+					jcc7ed51:::selected
+					9648dae(( ))
+					j40f95ac --> 9648dae
+					jcc7ed51 --> 9648dae
+					9648dae:::selected
+					9648dae --> 4ca63a1
+					4ca63a1:::selected
+					4ca63a1 --> stop
 					classDef error stroke:#f00
-					classDef selected stroke:#0f0
-				`,
+					classDef selected stroke:#0f0				`,
 		);
 	});
 
@@ -729,31 +727,31 @@ describe('Mermaid', () => {
 				graph TD
 					start(( ))
 					start -.- d0{ }
-					d0 -.- d90b3da[["increment counters"]]
-					d90b3da -.- dd89b07("a + 1")
-					dd89b07 -.- 0e3f56c("a + 1")
-					0e3f56c -.- f733eae("b + 1")
-					f733eae -.- 0bf9a34("b + 1")
-					0bf9a34 -.- d1{ }
-					d1 -.- e45e61b[["increment counters"]]
-					e45e61b -.- e45e61b-err[ ]
-					e45e61b-err:::error
-					d1 -.- eb5cff4("a + 1")
-					eb5cff4 -.- stop(( ))
+					d0 -.- b447e67[["increment counters"]]
+					b447e67 -.- 1c0350c("a + 1")
+					1c0350c -.- 7379b58("a + 1")
+					7379b58 -.- 4b05c26("b + 1")
+					4b05c26 -.- 619482f("b + 1")
+					619482f -.- d1{ }
+					d1 -.- 96a5cb1[["increment counters"]]
+					96a5cb1 -.- 96a5cb1-err[ ]
+					96a5cb1-err:::error
+					d1 -.- 7518c42("a + 1")
+					7518c42 -.- stop(( ))
 					stop:::finish
 					classDef finish stroke:#000,fill:#000
 					start:::selected
-					start --> dd89b07
-					dd89b07:::selected
-					dd89b07 --> 0e3f56c
-					0e3f56c:::selected
-					0e3f56c --> f733eae
-					f733eae:::selected
-					f733eae --> 0bf9a34
-					0bf9a34:::selected
-					0bf9a34 --> eb5cff4
-					eb5cff4:::selected
-					eb5cff4 --> stop
+					start --> 1c0350c
+					1c0350c:::selected
+					1c0350c --> 7379b58
+					7379b58:::selected
+					7379b58 --> 4b05c26
+					4b05c26:::selected
+					4b05c26 --> 619482f
+					619482f:::selected
+					619482f --> 7518c42
+					7518c42:::selected
+					7518c42 --> stop
 					classDef error stroke:#f00
 					classDef selected stroke:#0f0
 				`,

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -1,10 +1,10 @@
 import { isArrayIndex } from './is-array-index';
-import { Path } from './path';
+import { Path, PathString, Root } from './path';
 import { InvalidPointer } from './pointer';
 import { Ref } from './ref';
 import { Lens } from './lens';
 
-export interface View<TState, TPath extends Path = '/'>
+export interface View<TState, TPath extends PathString = Root>
 	extends Ref<Lens<TState, TPath>> {
 	delete(): void;
 }
@@ -12,12 +12,11 @@ export interface View<TState, TPath extends Path = '/'>
 /**
  * Returns a view builder function from a given path
  */
-function createView<TState, TPath extends Path>(
+function createView<TState, TPath extends PathString>(
 	ref: Ref<TState>,
-	path: TPath,
+	path: Path<TPath>,
 ): View<TState, TPath> {
-	Path.assert(path);
-	const parts = Path.elems(path);
+	const parts = Path.split(path);
 
 	// Save the last element of the path so we can delete it
 	const last = parts.pop();


### PR DESCRIPTION
This prevents the code from using simple string as paths, and ensures Path operations are used when splitting and transforming paths. The path constructor now allows passsing arrays as input, and path segments will be escaped according to IETF RFC 6901, preventing issues if using slashes as dictionary keys in the state object

The interface does not change for users.

Change-type: minor