### PR TITLE
Export Task constructor prop types

### DIFF
--- a/lib/agent/index.ts
+++ b/lib/agent/index.ts
@@ -131,10 +131,10 @@ export interface Agent<TState = any> extends Subscribable<TState> {
 type DeepPartial<T> = T extends any[] | ((...args: any[]) => any)
 	? T
 	: T extends object
-	  ? {
+		? {
 				[P in keyof T]?: DeepPartial<T[P]>;
-	    }
-	  : T;
+			}
+		: T;
 
 /**
  * Create a new agent

--- a/lib/identity.ts
+++ b/lib/identity.ts
@@ -2,5 +2,5 @@
 export type Identity<T> = T extends object
 	? object & {
 			[P in keyof T]: T[P];
-	  }
+		}
 	: T;

--- a/lib/lens.ts
+++ b/lib/lens.ts
@@ -25,7 +25,7 @@ type LensWithSlash<
 	: TProps & {
 			path: Path<TPath>;
 			target: unknown;
-	  }; // Otherwise, the path is invalid
+		}; // Otherwise, the path is invalid
 
 // A lens to evaluate paths that start without a slash, e.g. `key1/key2` or `key`
 type LensWithoutSlash<
@@ -50,13 +50,13 @@ type LensOnSinglePathWithParameter<
 				TPath,
 				number,
 				TProps & { [key in Arg]: number }
-		  >
+			>
 		: LensOnSinglePath<
 				TChildState,
 				TPath,
 				keyof TChildState,
 				TProps & { [key in Arg]: keyof TChildState }
-		  >
+			>
 	: LensOnSinglePath<TChildState, TPath, TParam, TProps>;
 
 // A lens on a single path, e.g. 'key'. In this case, the path is either a valid key for the object
@@ -69,9 +69,9 @@ type LensOnSinglePath<
 > = TKey extends ''
 	? LensOnEmptyPath<TChildState, TPath, TProps>
 	: // If the key is a valid key on the object of type S
-	  TKey extends keyof TChildState
-	  ? LensOnEmptyPath<TChildState[TKey], TPath, TProps> // Then evaluate the empty path
-	  : never; // If the key is not empty at this point, then the path is invalid
+		TKey extends keyof TChildState
+		? LensOnEmptyPath<TChildState[TKey], TPath, TProps> // Then evaluate the empty path
+		: never; // If the key is not empty at this point, then the path is invalid
 
 // The type of a change for an empty path, where the key is an empty string
 type LensOnEmptyPath<
@@ -101,7 +101,7 @@ type LensOnCompoundPathWithParameter<
 				keyof TChildState,
 				TTail,
 				TProps & { [K in Arg]: keyof TChildState }
-		  > // This is a compound path with a parameter. Add the key and continue evaluating
+			> // This is a compound path with a parameter. Add the key and continue evaluating
 	: LensOnCompoundPath<TChildState, TPath, THead, TTail, TProps>;
 
 // A compound path without parameters

--- a/lib/path.ts
+++ b/lib/path.ts
@@ -4,8 +4,8 @@ type PathBrand = { __brand: 'Path' };
 export type Path<T extends string[] | string = string> = T extends string[]
 	? `/${PathArray<T>}` & PathBrand
 	: T extends string
-	  ? T & PathBrand
-	  : never;
+		? T & PathBrand
+		: never;
 
 export type Root = '/';
 

--- a/lib/pointer.ts
+++ b/lib/pointer.ts
@@ -19,13 +19,13 @@ type PointerWithCompoundPath<
 > = O extends any[]
 	? PointerWithoutSlash<O[number], T>
 	: H extends keyof O
-	  ? PointerWithoutSlash<O[H], T>
-	  : never;
+		? PointerWithoutSlash<O[H], T>
+		: never;
 type PointerWithSinglePath<O, H extends string> = O extends any[]
 	? O[number]
 	: H extends keyof O
-	  ? O[H]
-	  : never;
+		? O[H]
+		: never;
 
 export class InvalidPointer extends Error {
 	constructor(path: PathType, obj: unknown) {

--- a/lib/target.ts
+++ b/lib/target.ts
@@ -8,24 +8,24 @@ type IsOptional<S extends object, K extends keyof S> = Omit<S, K> extends S
 export type Target<S> = S extends any[] | ((...args: any) => any)
 	? S
 	: S extends object
-	  ? {
+		? {
 				[P in keyof S]?: IsOptional<S, P> extends true
 					? // Only optional properties can be deleted
-					  Target<S[P]> | UNDEFINED
+						Target<S[P]> | UNDEFINED
 					: Target<S[P]>;
-	    }
-	  : S;
+			}
+		: S;
 
 type WithOptional<S> = S extends any[] | ((...args: any) => any)
 	? S
 	: S extends object
-	  ? {
+		? {
 				[P in keyof S]: IsOptional<S, P> extends true
 					? // Only optional properties can be undefined
-					  WithOptional<S[P]> | undefined
+						WithOptional<S[P]> | undefined
 					: WithOptional<S[P]>;
-	    }
-	  : S;
+			}
+		: S;
 
 function globToRegExp(glob: string): RegExp {
 	const parts = glob.split('*');

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -1,4 +1,5 @@
 export * from './tasks';
+export * from './props';
 export * from './instructions';
 export * from './helpers';
 export * from './context';

--- a/lib/task/props.ts
+++ b/lib/task/props.ts
@@ -14,15 +14,15 @@ type ReadOnlyPrimitive =
 	| ((...args: any[]) => any)
 	| Date;
 
-export type ReadOnly<T> = T extends ReadOnlyPrimitive
+type ReadOnly<T> = T extends ReadOnlyPrimitive
 	? T
 	: T extends Array<infer U>
-	  ? Array<ReadOnly<U>>
-	  : T extends Map<infer K, infer V>
-	    ? Map<ReadOnly<K>, ReadOnly<V>>
-	    : T extends Set<infer M>
-	      ? Set<ReadOnly<M>>
-	      : { readonly [K in keyof T]: ReadOnly<T[K]> };
+		? Array<ReadOnly<U>>
+		: T extends Map<infer K, infer V>
+			? Map<ReadOnly<K>, ReadOnly<V>>
+			: T extends Set<infer M>
+				? Set<ReadOnly<M>>
+				: { readonly [K in keyof T]: ReadOnly<T[K]> };
 
 export type ContextWithSystem<
 	TState = unknown,
@@ -35,13 +35,13 @@ export type ContextWithSystem<
  * instance. The description does not receive the current state to allow actions to
  * be compared by their description (useful for testing and debugging).
  */
-export type DescriptionFn<
+type DescriptionFn<
 	TState = unknown,
 	TPath extends PathType = Root,
 	TOp extends AnyOp = Update,
 > = string | ((c: Context<TState, TPath, TOp>) => string);
 
-export type ConditionFn<
+type ConditionFn<
 	TState = unknown,
 	TPath extends PathType = Root,
 	TOp extends AnyOp = Update,
@@ -50,7 +50,7 @@ export type ConditionFn<
 	c: ReadOnly<ContextWithSystem<TState, TPath, TOp>>,
 ) => boolean;
 
-export type EffectFn<
+type EffectFn<
 	TState = unknown,
 	TPath extends PathType = Root,
 	TOp extends AnyOp = Update,
@@ -59,7 +59,7 @@ export type EffectFn<
 	ctx: ContextWithSystem<TState, TPath, TOp>,
 ) => void;
 
-export type ActionFn<
+type ActionFn<
 	TState = unknown,
 	TPath extends PathType = Root,
 	TOp extends AnyOp = Update,
@@ -68,7 +68,7 @@ export type ActionFn<
 	ctx: ContextWithSystem<TState, TPath, TOp>,
 ) => Promise<void>;
 
-export type MethodFn<
+type MethodFn<
 	TState = unknown,
 	TPath extends PathType = Root,
 	TOp extends AnyOp = Update,
@@ -205,21 +205,4 @@ export type MethodTaskProps<
 	 * further instructions that can be applied
 	 */
 	method: MethodFn<TState, TPath, TOp>;
-};
-
-function isActionProps<
-	TState = unknown,
-	TPath extends PathType = Root,
-	TOp extends AnyOp = Update,
->(
-	x: ActionTaskProps<TState, TPath, TOp> | MethodTaskProps<TState, TPath, TOp>,
-): x is ActionTaskProps<TState, TPath, TOp> {
-	return (
-		typeof (x as any).effect === 'function' ||
-		typeof (x as any).action === 'function'
-	);
-}
-
-export const ActionTaskProps = {
-	is: isActionProps,
 };

--- a/lib/task/tasks.ts
+++ b/lib/task/tasks.ts
@@ -343,6 +343,21 @@ function isActionTask<
 	);
 }
 
+// We put this here instead of props so we don't export it externally when doing
+// export *	from props
+function isActionProps<
+	TState = unknown,
+	TPath extends PathType = Root,
+	TOp extends AnyOp = Update,
+>(
+	x: ActionTaskProps<TState, TPath, TOp> | MethodTaskProps<TState, TPath, TOp>,
+): x is ActionTaskProps<TState, TPath, TOp> {
+	return (
+		typeof (x as any).effect === 'function' ||
+		typeof (x as any).action === 'function'
+	);
+}
+
 /**
  * A task is base unit of knowledge of an autonomous agent.
  */
@@ -402,7 +417,7 @@ function from<
 
 	// The task properties
 	const tProps = (() => {
-		if (ActionTaskProps.is(taskProps)) {
+		if (isActionProps(taskProps)) {
 			const {
 				effect: taskEffect = () => void 0,
 				action: taskAction = async (v, c) => taskEffect(v, c),


### PR DESCRIPTION
This was an oversight from v3 which dissallowed using the `Domain` interface correctly.

Change-type: patch