### PR TITLE
Do not recurse into arrays when constructing Target

### DIFF
--- a/lib/distance.ts
+++ b/lib/distance.ts
@@ -138,9 +138,8 @@ function* getOperations<S>(
  * Calculates the list of changes between the current state and the target
  */
 export function diff<S>(s: S, t: Target<S>): Array<Operation<S, any>> {
-	return [...getOperations(s, t)]
-		.filter(({ isLeaf }) => isLeaf)
-		.map(({ isLeaf, ...op }) => op);
+	const ops = [...getOperations(s, t)];
+	return ops.filter(({ isLeaf }) => isLeaf).map(({ isLeaf, ...op }) => op);
 }
 
 function from<S>(src: S, tgt: Target<S>): Distance<S> {

--- a/lib/target.spec.ts
+++ b/lib/target.spec.ts
@@ -66,5 +66,16 @@ describe('Target', () => {
 				g: { h: 'hello' },
 			});
 		});
+
+		it('does not iterate into arrays', () => {
+			type S = {
+				a?: string[];
+			};
+
+			const state: S = { a: ['foo', 'bar'] };
+			expect(Target.from(state, {})).to.deep.equal({ a: UNDEFINED });
+			expect(Target.from(state, { a: ['foo'] })).to.deep.equal({ a: ['foo'] });
+			expect(Target.from(state, { a: ['bar'] })).to.deep.equal({ a: ['bar'] });
+		});
 	});
 });

--- a/lib/target.ts
+++ b/lib/target.ts
@@ -55,6 +55,10 @@ function from<S>(
 	while (queue.length > 0) {
 		const { s, t, p } = queue.shift()!;
 
+		// Don't recurse into arrays
+		if (Array.isArray(s) || Array.isArray(t)) {
+			continue;
+		}
 		for (const key of Object.keys(s)) {
 			if (key in t && t[key] === undefined && s[key] !== undefined) {
 				t[key] = UNDEFINED;

--- a/tests/orchestrator/planning.spec.ts
+++ b/tests/orchestrator/planning.spec.ts
@@ -120,7 +120,7 @@ describe('orchestrator/planning', () => {
 				},
 			},
 			keys: {},
-			images: [{ name: 'a0_main:r0' }],
+			images: { 'a0_main:r0': { name: 'alpine:latest' } },
 		};
 
 		const result = planner.findPlan(device, {


### PR DESCRIPTION
The `Distance` module does not compare array elements, so the `Target` constructor should not replace removed elements with `UNDEFINED`

Change-type: patch