### PR TITLE
Export `deepEqual` and `UnorderedArray` as part of the `utils` namespace

### DIFF
--- a/lib/distance.ts
+++ b/lib/distance.ts
@@ -2,7 +2,7 @@ import { Operation } from './operation';
 import { Pointer } from './pointer';
 import { Path } from './path';
 import { Target, UNDEFINED } from './target';
-import { equals } from './json';
+import { deepEqual } from './utils';
 
 /**
  * A diff is a function that allows to find a list of pending operations to a
@@ -84,7 +84,7 @@ function* getOperations<S>(
 			}
 			// If the source value does exist, we do a deep comparison compare the source to the patched
 			// version and if they don't match, we add an `update` operation
-			else if (!equals(sValue, tValue)) {
+			else if (!deepEqual(sValue, tValue)) {
 				yield {
 					op: 'update',
 					path,

--- a/lib/task/props.ts
+++ b/lib/task/props.ts
@@ -17,11 +17,11 @@ type ReadOnlyPrimitive =
 type ReadOnly<T> = T extends ReadOnlyPrimitive
 	? T
 	: T extends Array<infer U>
-		? Array<ReadOnly<U>>
+		? T & Array<ReadOnly<U>>
 		: T extends Map<infer K, infer V>
-			? Map<ReadOnly<K>, ReadOnly<V>>
+			? T & Map<ReadOnly<K>, ReadOnly<V>>
 			: T extends Set<infer M>
-				? Set<ReadOnly<M>>
+				? T & Set<ReadOnly<M>>
 				: { readonly [K in keyof T]: ReadOnly<T[K]> };
 
 export type ContextWithSystem<

--- a/lib/utils/deep-equal.spec.ts
+++ b/lib/utils/deep-equal.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from '~/test-utils';
+import { deepEqual } from './deep-equal';
+
+describe('deepEqual', () => {
+	it('allows to compare objects of equal type', () => {
+		expect(deepEqual(1, 1)).to.be.true;
+		expect(deepEqual(1, 2)).to.be.false;
+		expect(deepEqual(1.0, 0x01)).to.be.true;
+		expect(deepEqual(1.1, 1.1)).to.be.true;
+		expect(deepEqual('a', 'a')).to.be.true;
+		expect(deepEqual('b', 'a')).to.be.false;
+		expect(deepEqual('b', 'a')).to.be.false;
+		expect(deepEqual([0, 1, 2], [0, 1, 2])).to.be.true;
+		expect(deepEqual([1, 0, 2], [0, 1, 2])).to.be.false;
+		expect(deepEqual({ a: 1 }, { a: 1 })).to.be.true;
+		expect(deepEqual({ a: 1 }, { a: 2 })).to.be.false;
+		expect(deepEqual({ a: { b: 0 } }, { a: 2 })).to.be.false;
+		expect(deepEqual({ a: { b: 0 } }, { a: { b: 1 } })).to.be.false;
+		expect(deepEqual({ a: { b: 0 } }, { a: { b: 0 } })).to.be.true;
+		expect(
+			deepEqual(
+				{ a: { b: 0, c: { d: 'hello' } } },
+				{ a: { b: 0, c: { d: [0, 1] } } },
+			),
+		).to.be.false;
+		expect(
+			deepEqual(
+				{ a: { b: 0, c: { d: 'hello' } } },
+				{ a: { b: 0, c: { d: 'hello' } } },
+			),
+		).to.be.true;
+	});
+
+	it('allows to compare objecs using the Eq interface', () => {
+		class UnorderedArray<T> extends Array<T> {
+			equals(other: T[]) {
+				if (this.length !== other.length) {
+					return false;
+				}
+
+				const a = [...this];
+				const b = [...other];
+
+				a.sort();
+				b.sort();
+
+				return a.every((x, i) => deepEqual(x, b[i]));
+			}
+		}
+
+		expect(deepEqual(new UnorderedArray(0, 1, 2), new UnorderedArray(1, 0, 2)))
+			.to.be.true;
+		expect(deepEqual(new UnorderedArray(0, 1, 2), new UnorderedArray(1, 3, 2)))
+			.to.be.false;
+	});
+});

--- a/lib/utils/deep-equal.ts
+++ b/lib/utils/deep-equal.ts
@@ -3,10 +3,32 @@ function isObject(value: unknown): value is object {
 }
 
 /**
+ * Generic interface for type equality
+ */
+interface Eq {
+	equals<O = this>(other: O): boolean;
+}
+
+const Eq = {
+	is(x: unknown): x is Eq {
+		return isObject(x) && typeof (x as any).equals === 'function';
+	},
+};
+
+/**
  * Calculates deep equality between javascript
  * objects
  */
-export function equals<T>(value: T, other: T): boolean {
+export function deepEqual<T>(value: T, other: T): boolean {
+	// Allow user to override the comparison
+	if (Eq.is(value)) {
+		return value.equals(other);
+	}
+
+	if (Eq.is(other)) {
+		return other.equals(value);
+	}
+
 	if (isObject(value) && isObject(other)) {
 		const [vProps, oProps] = [value, other].map(
 			(a) => Object.getOwnPropertyNames(a) as Array<keyof T>,
@@ -20,7 +42,7 @@ export function equals<T>(value: T, other: T): boolean {
 		// Otherwise this comparison will catch it. This works even
 		// for arrays as getOwnPropertyNames returns the list of indexes
 		// for each array
-		return vProps.every((key) => equals(value[key], other[key]));
+		return vProps.every((key) => deepEqual(value[key], other[key]));
 	}
 
 	return value === other;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './deep-equal';

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './deep-equal';
+export * from './unordered-array';

--- a/lib/utils/unordered-array.spec.ts
+++ b/lib/utils/unordered-array.spec.ts
@@ -1,0 +1,38 @@
+import { expect } from '~/test-utils';
+import { UnorderedArray } from './unordered-array';
+
+describe('UnorderedArray', () => {
+	it('allows to find elements via deep equality', () => {
+		expect(UnorderedArray.of(0, 1, 2, 3).includes(2)).to.be.true;
+		expect(UnorderedArray.of(0, 1, 2, 3).includes(5)).to.be.false;
+		expect(new UnorderedArray('a', 'b', 'c').includes('a')).to.be.true;
+		expect(new UnorderedArray('a', 'b', 'c').includes('f')).to.be.false;
+		expect(new UnorderedArray({ a: 0 }, { a: 1 }, { b: 0 }).includes({ a: 0 }))
+			.to.be.true;
+		expect(new UnorderedArray({ a: 0 }, { a: 1 }, { b: 0 }).includes({ a: 3 }))
+			.to.be.false;
+	});
+
+	it('allows comparisons ignoring the order', () => {
+		expect(
+			UnorderedArray.of({ a: 0 }, { a: 0 }, { b: 1 }).equals([
+				{ b: 1 },
+				{ a: 0 },
+			]),
+		).to.be.false;
+		expect(
+			UnorderedArray.of({ a: 0 }, { b: 1 }).equals([
+				{ a: 0 },
+				{ a: 0 },
+				{ b: 1 },
+			]),
+		).to.be.false;
+		expect(UnorderedArray.of({ a: 0 }, { b: 1 }).equals([{ b: 1 }, { a: 0 }]))
+			.to.be.true;
+	});
+
+	it('UnorderedArray is also an Array', () => {
+		expect(UnorderedArray.of(0, 1, 2) instanceof Array).to.be.true;
+		expect(Array.isArray(UnorderedArray.of(0, 1, 2))).to.be.true;
+	});
+});

--- a/lib/utils/unordered-array.ts
+++ b/lib/utils/unordered-array.ts
@@ -1,0 +1,58 @@
+import { deepEqual } from './deep-equal';
+
+/**
+ * UnorderedArray provides an interface for array comparisons where the comparison
+ * is independent of the order. This is useful when for a state model where someone
+ * might not want to consider reordering of data in an array to be considered a state
+ * change.
+ */
+export interface UnorderedArray<T> extends Array<T> {
+	equals(o: ArrayLike<T>): boolean;
+}
+
+class UnorderedArrayImpl<T> extends Array<T> implements UnorderedArray<T> {
+	static of<T>(...items: T[]): UnorderedArray<T> {
+		return new UnorderedArrayImpl(...items);
+	}
+
+	static from<T>(items: ArrayLike<T> | Iterable<T> = []): UnorderedArray<T> {
+		return new UnorderedArrayImpl(...Array.from(items));
+	}
+
+	includes(value: T): boolean {
+		for (const elem of this) {
+			if (deepEqual(value, elem)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private difference(other: UnorderedArray<T>): T[] {
+		const result = [];
+
+		for (const elem of this) {
+			if (!other.includes(elem)) {
+				result.push(elem);
+			}
+		}
+
+		return result;
+	}
+
+	equals(other: ArrayLike<T>): boolean {
+		// If the arrays have different length then return false
+		// immediately
+		if (this.length !== other.length) {
+			return false;
+		}
+
+		// Otherwise the arrays are equal if A - B = B - A = 0
+		const otherArr = new UnorderedArrayImpl(...Array.from(other));
+		const diffA = this.difference(otherArr);
+		const diffB = otherArr.difference(this);
+		return diffA.length === 0 && diffB.length === 0;
+	}
+}
+
+export const UnorderedArray = UnorderedArrayImpl;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./build/index.js",
     "./testing": "./build/testing/index.js",
-    "./planner": "./build/planner/index.js"
+    "./planner": "./build/planner/index.js",
+    "./utils": "./build/utils/index.js"
   },
   "types": "build/index.d.ts",
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
 			"mahler/planner": [
 				"lib/planner/index.ts"
 			],
+			"mahler/utils": [
+				"lib/utils/index.ts"
+			],
 			"~/test-utils": [
 				"tests/index.ts"
 			]


### PR DESCRIPTION
The `deepEqual` function is a key piece of how the distance to a target is calculated, as it allows to compare between the current and target state. This function is flexible to allow users to define their own comparison operations by providing an `equals` function on their models.

This function may also come handy for users of the library, so we export it as part of the `mahler/utils` namespace

We also export a new type `UnorderedArray` that can be used as part of the data model to indicate the planner that array comparison should not take into account the order of elements when comparing state.

Change-type: minor