### PR TITLE
Add support for 'strict' targets on the Agent interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,17 @@ agent.seek({ counter: 3, lastRead: UNDEFINED });
 agent.seek({ counter: 3, lastRead: undefined });
 ```
 
+You can also use the `seekStrict` function of `Agent` to tell the agent to look for the exact state given as the target
+
+```ts
+// This tells the agent the exact system state that
+// we want to see at the end of the run.
+agent.seekStrict({ counter: 3, needsWrite: true });
+
+// The above is equivalent to
+agent.seek({ counter: 3, lastRead: UNDEFINED });
+```
+
 We'll learn later how we can add an `op` property to tasks to tell Mahler when a task is applicable to a `delete` [operation](#operations).
 
 One last thing before moving on from this topic. What if you assign a required value the value of `UNDEFINED`?

--- a/lib/agent.spec.ts
+++ b/lib/agent.spec.ts
@@ -340,6 +340,23 @@ describe('Agent', () => {
 			agent.stop();
 		});
 
+		it('it should terminate once the strict target has been reached', async () => {
+			const roomTemp = 30;
+			resistorOn = true;
+			const agent = Agent.from({
+				initial: { roomTemp, resistorOn },
+				tasks: [turnOn, turnOff, wait],
+				sensors: [termometer(roomTemp)],
+				opts: { minWaitMs: 10, logger },
+			});
+			agent.seekStrict({ roomTemp: 20, resistorOn: false });
+			await expect(agent.wait(1000)).to.eventually.deep.equal({
+				success: true,
+				state: { roomTemp: 20, resistorOn: false },
+			}).fulfilled;
+			agent.stop();
+		});
+
 		it('it should allow observers to subcribe to the agent state', async () => {
 			const roomTemp = 18;
 			resistorOn = false;

--- a/lib/agent/types.ts
+++ b/lib/agent/types.ts
@@ -36,6 +36,12 @@ export interface AgentOpts {
 	 * A Logger instance to use for reporting
 	 */
 	logger: Logger;
+
+	/**
+	 * List of globs to ignore when converting a strict target to a relative target
+	 * when using `seekStrict`
+	 */
+	strictIgnore: string[];
 }
 
 /**

--- a/lib/target.spec.ts
+++ b/lib/target.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '~/test-utils';
 import { Target, UNDEFINED } from './target';
 
 describe('Target', () => {
-	describe('from', () => {
+	describe('fromStrict', () => {
 		it('adds UNDEFINED symbols for missing values on the target', () => {
 			type S = {
 				a: number;
@@ -18,7 +18,7 @@ describe('Target', () => {
 			};
 
 			expect(
-				Target.from(state, {
+				Target.fromStrict(state, {
 					a: 1,
 					c: { d: { e: 3, f: undefined } },
 					g: { h: 'hello' },
@@ -48,7 +48,7 @@ describe('Target', () => {
 			};
 
 			expect(
-				Target.from(
+				Target.fromStrict(
 					state,
 					{
 						a: 1,
@@ -73,9 +73,13 @@ describe('Target', () => {
 			};
 
 			const state: S = { a: ['foo', 'bar'] };
-			expect(Target.from(state, {})).to.deep.equal({ a: UNDEFINED });
-			expect(Target.from(state, { a: ['foo'] })).to.deep.equal({ a: ['foo'] });
-			expect(Target.from(state, { a: ['bar'] })).to.deep.equal({ a: ['bar'] });
+			expect(Target.fromStrict(state, {})).to.deep.equal({ a: UNDEFINED });
+			expect(Target.fromStrict(state, { a: ['foo'] })).to.deep.equal({
+				a: ['foo'],
+			});
+			expect(Target.fromStrict(state, { a: ['bar'] })).to.deep.equal({
+				a: ['bar'],
+			});
 		});
 	});
 });

--- a/lib/target.spec.ts
+++ b/lib/target.spec.ts
@@ -55,7 +55,26 @@ describe('Target', () => {
 						c: { d: { e: 3, f: undefined } },
 						g: { h: 'hello' },
 					},
-					['/b', '*/g', '/c/*/f'],
+					['/b', '/g', '/c/*/f'],
+				),
+			).to.deep.equal({
+				a: 1,
+				c: {
+					d: { e: 3, f: UNDEFINED },
+					h: UNDEFINED,
+				},
+				g: { h: 'hello', i: UNDEFINED },
+			});
+
+			expect(
+				Target.fromStrict(
+					state,
+					{
+						a: 1,
+						c: { d: { e: 3, f: undefined } },
+						g: { h: 'hello' },
+					},
+					['/b', '*/g/*', '/c/*/f'],
 				),
 			).to.deep.equal({
 				a: 1,

--- a/lib/target.ts
+++ b/lib/target.ts
@@ -10,7 +10,7 @@ type IsOptional<S extends object, K extends keyof S> =
  * A Target in Mahler is by default 'relative', meaning that only property
  * changes and additions should be considered when comparing current and
  * target states for planning. Property deletion need to be done explicitely
- * via the `UNDEFINED` symbol. This allows a cleeaner interface for for
+ * via the `UNDEFINED` symbol. This allows a cleaner interface for for
  * defining system targets and allows the system state to have additional properties
  * than the target.
  *

--- a/lib/target.ts
+++ b/lib/target.ts
@@ -106,15 +106,24 @@ function fromStrict<S>(
 			continue;
 		}
 		for (const key of Object.keys(s)) {
+			// If the target is explicitely set as `undefined` replace
+			// the target with the `UNDEFINED` symbol
 			if (key in t && t[key] === undefined && s[key] !== undefined) {
 				t[key] = UNDEFINED;
-			} else if (ignore.some((r) => r.test(`${p}/${key}`))) {
+			}
+			// If the key doesn't exist on the target but the path
+			// matches one the globs, ignore it
+			else if (!(key in t) && ignore.some((r) => r.test(`${p}/${key}`))) {
 				continue;
-			} else if (!(key in t)) {
+			}
+			// If the path does not match any glob, mark the element to be
+			// deleted
+			else if (!(key in t)) {
 				// UNDEFINED means delete the value
 				t[key] = UNDEFINED;
-			} else if (typeof t[key] === 'object') {
-				// If the value is an object, we need to recurse
+			}
+			// Otherwise, if the value is an object, we need to recurse
+			else if (typeof t[key] === 'object') {
 				queue.push({ s: s[key], t: t[key], p: `${p}/${key}` });
 			}
 		}

--- a/lib/target.ts
+++ b/lib/target.ts
@@ -4,6 +4,31 @@ export type UNDEFINED = typeof UNDEFINED;
 type IsOptional<S extends object, K extends keyof S> =
 	Omit<S, K> extends S ? true : false;
 
+/**
+ * A target is a partial state that can be used to update
+ *
+ * A Target in Mahler is by default 'relative', meaning that only property
+ * changes and additions should be considered when comparing current and
+ * target states for planning. Property deletion need to be done explicitely
+ * via the `UNDEFINED` symbol. This allows a cleeaner interface for for
+ * defining system targets and allows the system state to have additional properties
+ * than the target.
+ *
+ * Example: let's say we are modelling the state of two variables `x` and `y`.
+ *
+ * Given the current state `{x: 0}`, the target state `{y: 1}` means that the
+ * planner needs to only to find a task that can create the variable `y` and increase its
+ * value to `1`. The final expected state should be `{x: 0, y:1}` (assuming nothing else changes `x`).
+ *
+ * If the goal was to remove the variable `x` at the same time that variable `y` is introduced, the
+ * target would need to be `{x: UNDEFINED, y: 1}`.
+ *
+ * A 'relative' target is the opposite to a 'strict' (or absolute) target, where what is passed to
+ * the planner/agent describes exactly the desired state of the system is.
+ *
+ * In the previous example, the strict target `{y:1}` is equivalent to the relative target `{x: UNDEFINED, y: 1}`,
+ * meaning the strict target describes the expected state of the system.
+ */
 export type Target<S> = S extends any[] | ((...args: any) => any)
 	? S
 	: S extends object
@@ -15,14 +40,20 @@ export type Target<S> = S extends any[] | ((...args: any) => any)
 			}
 		: S;
 
-type WithOptional<S> = S extends any[] | ((...args: any) => any)
+/**
+ * A strict target describes the desired system state in an 'absolute' way
+ *
+ * Absolute, in this context, means that after a plan has been successfully been
+ * found, the system state should look exactly like the given target.
+ */
+export type StrictTarget<S> = S extends any[] | ((...args: any) => any)
 	? S
 	: S extends object
 		? {
 				[P in keyof S]: IsOptional<S, P> extends true
 					? // Only optional properties can be undefined
-						WithOptional<S[P]> | undefined
-					: WithOptional<S[P]>;
+						StrictTarget<S[P]> | undefined
+					: StrictTarget<S[P]>;
 			}
 		: S;
 
@@ -33,16 +64,32 @@ function globToRegExp(glob: string): RegExp {
 }
 
 /**
- * Create a new target from the current state and
- * a partial state. This is useful to have a cleaner interface
- * that just provides the values that need to be changed.
+ * Create a new relative target from the given strict target and the
+ * current state.
  *
- * The process will skip any target paths matching the given globs. Note that glob
- * support is very limited, and only supports `*` as special characters.
+ * This will look any missing properties on the target and replace them with
+ * `UNDEFINED` symbols in order to mark them for deletion.
+ *
+ * Because sometimes it is useful to have properties on the current state
+ * that are not needed on the target, this function receives a
+ * list of 'globs' indicating which properties to ignore. Properties in the `ignoreGlobs`
+ * list will be skipped when marking properties to be deleted.
+ *
+ * Example.
+ * ```
+ * // Current state
+ * const s = {x: 1, y:0, lastUpdated: '20240408T12:00:00Z'};
+ *
+ * // Calculate target state
+ * const target = Target.fromStrict(s, {y: 1}, ['lastUpdated']);
+ * console.log(target); // {x: UNDEFINED, y: 1}
+ * ```
+ *
+ * Note that glob support is very limited, and only supports `*` as special characters.
  */
-function from<S>(
+function fromStrict<S>(
 	state: S,
-	target: WithOptional<S>,
+	target: StrictTarget<S>,
 	ignoreGlobs = [] as string[],
 ): Target<S> {
 	const queue: Array<{ s: any; t: any; p: string }> = [
@@ -77,5 +124,12 @@ function from<S>(
 }
 
 export const Target = {
-	from,
+	/**
+	 * Create a new relative target from the given strict target and the
+	 * current state.
+	 *
+	 * @deprecated to be replaced by fromStrict
+	 */
+	from: fromStrict,
+	fromStrict,
 };


### PR DESCRIPTION
A Target in Mahler is by default 'relative', meaning that only property
changes and additions should be considered when comparing current and
target states for planning. Property deletion need to be done explicitely
via the `UNDEFINED` symbol. This allows a cleaner interface for for
defining system targets and allows the system state to have additional properties
than the target.

A 'relative' target is the opposite to a 'strict' (or absolute) target, where what is passed to
the planner/agent describes exactly the desired state of the system is.

This PR introduces the `StrictTarget` type and the `seekStrict` method
on the `Agent` interface. This allows users some additional flexibility
to specify an absolute state of the final system.

Example: let's say we are modelling the state of two variables `x` and `y`.

Given the current state `{x: 0}`, the target state `{y: 1}` means that the
planner needs to only to find a task that can create the variable `y` and increase its
value to `1`. The final expected state should be `{x: 0, y:1}` (assuming nothing else changes `x`).

If the goal was to remove the variable `x` at the same time that variable `y` is introduced, the
relative target would need to be `{x: UNDEFINED, y: 1}`

The equivalent strict target in this case is just `{y: 1}`.

Change-type: minor